### PR TITLE
Add CLAUDE.md, agent skills, and fix lint/formatting

### DIFF
--- a/.claude/skills/logs/SKILL.md
+++ b/.claude/skills/logs/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: logs
+description: |
+  Read production logs from GCP Cloud Logging for the npc-mixpanel Cloud Run
+  services. Queries BOTH the UI service (npc-mixpanel) and API service
+  (npc-mixpanel-api). Use when the user says "check logs", "show logs",
+  "what happened in prod", "any errors", or asks about production behavior.
+---
+
+# Read Production Logs
+
+Query Cloud Run logs for both npc-mixpanel services in GCP project `mixpanel-gtm-training`, region `us-central1`.
+
+## Services
+
+| Service | Name               | Context                              |
+| ------- | ------------------ | ------------------------------------ |
+| UI      | `npc-mixpanel`     | Private, IAP-protected web interface |
+| API     | `npc-mixpanel-api` | Public API endpoint                  |
+
+## Quick log read (both services)
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND (resource.labels.service_name="npc-mixpanel" OR resource.labels.service_name="npc-mixpanel-api") AND resource.labels.location="us-central1" AND severity>=DEFAULT AND log_name!~"watcher_log|cloudaudit"' \
+  --project=mixpanel-gtm-training \
+  --limit=50 \
+  --format="json" \
+  --freshness=1h
+```
+
+## UI service logs only
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="npc-mixpanel" AND resource.labels.location="us-central1" AND severity>=DEFAULT AND log_name!~"watcher_log|cloudaudit"' \
+  --project=mixpanel-gtm-training \
+  --limit=50 \
+  --format="json" \
+  --freshness=1h
+```
+
+## API service logs only
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="npc-mixpanel-api" AND resource.labels.location="us-central1" AND severity>=DEFAULT AND log_name!~"watcher_log|cloudaudit"' \
+  --project=mixpanel-gtm-training \
+  --limit=50 \
+  --format="json" \
+  --freshness=1h
+```
+
+## Errors only (both services)
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND (resource.labels.service_name="npc-mixpanel" OR resource.labels.service_name="npc-mixpanel-api") AND severity>=ERROR' \
+  --project=mixpanel-gtm-training \
+  --limit=20 \
+  --format="json" \
+  --freshness=24h
+```
+
+## Filter by specific simulation/job
+
+Look for meeple-related log entries with context:
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="npc-mixpanel-api" AND textPayload=~"meeple"' \
+  --project=mixpanel-gtm-training \
+  --limit=50 \
+  --format="json" \
+  --freshness=6h
+```
+
+## Structured logs (from cloudLogger.js)
+
+The app uses `utils/cloudLogger.js` for structured GCP logging. These appear in `jsonPayload`:
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND (resource.labels.service_name="npc-mixpanel" OR resource.labels.service_name="npc-mixpanel-api") AND jsonPayload.message!=""' \
+  --project=mixpanel-gtm-training \
+  --limit=30 \
+  --format="json" \
+  --freshness=1h
+```
+
+## Check recent deployments
+
+```bash
+gcloud run revisions list \
+  --service=npc-mixpanel \
+  --region=us-central1 \
+  --project=mixpanel-gtm-training \
+  --limit=5
+
+gcloud run revisions list \
+  --service=npc-mixpanel-api \
+  --region=us-central1 \
+  --project=mixpanel-gtm-training \
+  --limit=5
+```
+
+## Adjusting queries
+
+- Change `--freshness` to widen/narrow the time window (e.g., `6h`, `24h`, `7d`)
+- Change `--limit` for more/fewer results
+- Add `AND textPayload=~"SEARCH_TERM"` to grep for specific text
+- Add `AND severity>=WARNING` to filter by severity level
+- Use `--format="table(timestamp,severity,textPayload)"` for compact output
+
+## Tips
+
+- User says "check logs" with no qualifier → query both services, last 1h, errors first
+- User mentions API or simulate → focus on `npc-mixpanel-api`
+- User mentions UI or interface → focus on `npc-mixpanel`
+- Always show timestamps and severity in output summaries
+- If logs are empty, check `--freshness` — services may have been idle

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ship
+description: |
+  Verify, commit, push, create PR, and deploy to Cloud Run via CI. Use when the
+  user says "ship it", "ship", "deploy", "push and merge", or asks to commit and
+  deploy changes. This project deploys TWO Cloud Run services (UI + API) from a
+  single CI pipeline. Handles: picking up ALL local changes (not just this
+  session's), running /verify, creating PRs, and auto-merging. Returns the PR URL
+  and GitHub Action link immediately — does not wait for CI to finish.
+---
+
+# Ship
+
+Verify, commit, and deploy changes to production via CI. Both services (UI + API) deploy from one push to main.
+
+## Step 1: Verify first
+
+Run the `/verify` skill. If anything fails, stop and report.
+
+```bash
+npm run validate && npm test
+```
+
+**Note:** Typecheck has known pre-existing errors in `forms.js` and `interactions.js`. Only fail on NEW errors — compare against known baseline (6 TS errors in forms.js, 1 unused var in interactions.js).
+
+## Step 2: Gather ALL changes
+
+Pick up everything — not just changes this Claude session made. The user often edits configs or makes changes before starting Claude.
+
+```bash
+git status
+git diff --stat
+git log --oneline -5
+```
+
+If `package.json` or `package-lock.json` are modified, they MUST be staged. Cloud Run builds from the git tree — unstaged lockfile = old version in prod.
+
+## Step 3: Branch, stage, and commit
+
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If on `main`, create a feature branch derived from the changes.
+
+Stage relevant files (never `.env`, `service-account.json`, `gcp-service-account-key.json`, or `node_modules`). Commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<subject line>
+
+<optional body>
+
+Co-Authored-By: AK <ak@mixpanel.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Step 4: Push, PR, auto-merge
+
+```bash
+git push -u origin <branch-name>
+
+gh pr create --title "<short title>" --body "$(cat <<'EOF'
+## Summary
+<bullet points>
+
+## Services affected
+- **UI** (`npc-mixpanel`) — Cloud Run, private/IAP
+- **API** (`npc-mixpanel-api`) — Cloud Run, public
+
+## Test plan
+- [x] `npm run validate` passes
+- [x] `npm test` passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+gh pr merge <PR_NUMBER> --auto --squash --delete-branch
+```
+
+## Step 5: Report and return
+
+Don't wait for CI. Report immediately:
+
+- PR URL
+- GitHub Actions link (from `gh run list --limit 1`)
+- What's deploying (one-line summary)
+- Reminder: CI deploys **both** UI and API services
+
+Then clean up:
+
+```bash
+git checkout main && git pull
+```
+
+## Important
+
+- **Never `npm run deploy`** from local — all deploys through CI (GitHub Actions → Cloud Build)
+- **Never force push** or amend published commits
+- **Never skip CI checks**
+- **Never merge to main directly** — always go through a PR
+- CI pipeline: GitHub Actions triggers Cloud Build twice (once per `cloudbuild.yaml` and `cloudbuild-api.yaml`)
+- If auto-merge fails with "no required protected branch rules", fall back to
+  `gh pr checks <PR_NUMBER> --watch && gh pr merge <PR_NUMBER> --squash --delete-branch`

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: verify
+description: |
+  Run all quality checks before shipping. Use when the user says "verify",
+  "check everything", "run checks", or before any deploy/ship operation.
+  Runs typecheck, lint, format check, and tests. Reports pass/fail with
+  awareness of known pre-existing issues.
+---
+
+# Verify
+
+Run all quality gates. This is the pre-ship checklist.
+
+## Step 1: Run validate (typecheck + lint + format)
+
+```bash
+npm run validate
+```
+
+### Known pre-existing typecheck errors (do NOT fail on these)
+
+The following errors exist in the codebase and are not regressions:
+
+- `meeple/forms.js` — 5 TS2345 errors: `ElementHandle<Node>` not assignable to `ElementHandle<Element>` (lines 486, 489, 492, 497, 499)
+- `meeple/interactions.js` — 1 TS6133 error: `hotZones` declared but never read (line 1306)
+- `meeple/sequences.js` — uses `@ts-nocheck` (suppresses all TS errors in that file)
+
+**Total known: 6 errors.** If typecheck reports exactly these 6, it's a pass. If there are NEW errors beyond these, it's a fail.
+
+## Step 2: Run lint
+
+If validate passed lint already ran. If validate failed on typecheck, run lint separately:
+
+```bash
+npm run lint
+```
+
+Lint must pass clean — zero warnings, zero errors.
+
+## Step 3: Run format check
+
+```bash
+npm run format:check
+```
+
+If formatting issues found, fix with `npm run format` and re-check.
+
+## Step 4: Run tests
+
+```bash
+npm test
+```
+
+Tests must pass. If tests fail, investigate and report — do not ship.
+
+## Reporting
+
+Summarize results as:
+
+```
+✓ Typecheck: pass (6 known pre-existing errors, no new errors)
+✓ Lint: pass
+✓ Format: pass
+✓ Tests: pass (X tests, X suites)
+```
+
+Or flag failures clearly with the specific error output.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,20 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     cooldown:
       default-days: 30
-  - package-ecosystem: "docker"
-    directory: "/"
+  - package-ecosystem: 'docker'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     cooldown:
       default-days: 30
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     cooldown:
       default-days: 30

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed  # v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f  # v2
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
         with:
           project_id: ${{ secrets.GCP_PROJECT }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,8 @@ logs/*
 .env.yaml
 env.yaml
 .cache
-.claude
+.claude/settings.local.json
 .prettierrc
-CLAUDE.md
 vscode-profile-*
 spec-*.jsonc
 service-account.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+## Project Overview
+
+**npc-mixpanel** — cloud-based web automation service simulating realistic user behavior on websites using Puppeteer. Generates synthetic analytics data for Mixpanel by orchestrating "Meeples" (NPCs) that behave like real users.
+
+## Commands
+
+```bash
+npm run local          # Start dev server (./scripts/local.sh)
+npm run fire           # POST scripts/payload.json to localhost:8080
+npm test               # Jest + Puppeteer (NODE_ENV=test)
+npm run validate       # Typecheck + lint + format check
+npm run typecheck      # TypeScript type checking (no emit, JS codebase)
+npm run lint           # ESLint
+npm run lint:fix       # ESLint with auto-fix
+npm run format         # Prettier (tabs, single quotes, 120-char width)
+npm run format:check   # Check formatting
+npm run deploy         # Deploy both UI + API services
+npm run deploy:ui      # Deploy UI only (Cloud Run, private)
+npm run deploy:api     # Deploy API only (Cloud Run, public)
+```
+
+## Architecture
+
+### Core Files
+
+- **server.js** — Express + Socket.IO server. Runtime-aware via `RUNTIME_CONTEXT` env var
+- **microsites.js** — Multi-site orchestrator (runs sequential simulations across 6 microsites)
+- **index.d.ts** — TypeScript definitions for all core types
+
+### Meeple Modules (`meeple/`)
+
+Modular automation engine. All functions accept a `log` parameter for per-meeple scoped logging.
+
+| Module            | Purpose                                                     |
+| ----------------- | ----------------------------------------------------------- |
+| `headless.js`     | Main orchestrator, entry point: `main(PARAMS, logFunction)` |
+| `browser.js`      | Browser config, launch, stealth setup                       |
+| `security.js`     | Anti-detection techniques                                   |
+| `navigation.js`   | Page navigation, URL handling                               |
+| `interactions.js` | Human-like mouse movements, clicks, scrolling               |
+| `forms.js`        | Form filling and submission                                 |
+| `hotzones.js`     | Interactive element detection and targeting                 |
+| `entities.js`     | User entity generation                                      |
+| `personas.js`     | User behavior patterns                                      |
+| `sequences.js`    | Deterministic sequence execution engine                     |
+| `analytics.js`    | Mixpanel tracking integration                               |
+| `utils.js`        | Shared helpers                                              |
+| `agents.json`     | Realistic browser fingerprints for UA spoofing              |
+
+### Utils (`utils/`)
+
+- **logger.js** — WebSocket + console logging with meeple ID routing
+- **cloudLogger.js** — GCP Cloud Logging structured logger
+- **injectMixpanel.js** — Mixpanel SDK injection with CSP workarounds and fallbacks
+
+### Middleware (`middleware/`)
+
+- **runtimeGuard.js** — Route access control based on `RUNTIME_CONTEXT`. Exports `createRuntimeGuard()`, `authenticateApi(req)`, `isApiContext`
+
+### UI (`ui/`)
+
+- **ui.html** + **app.js** + **styles.css** — Web interface with per-meeple tabbed terminal for real-time log streams
+
+## Dual-Service Architecture
+
+Same container deploys as two Cloud Run services, differentiated by `RUNTIME_CONTEXT`:
+
+|               | UI Service (`npc-ui`) | API Service (`npc-api`)                                  |
+| ------------- | --------------------- | -------------------------------------------------------- |
+| Auth          | Private (IAP)         | Public, requires `user_id` (@mixpanel.com) + `safe_word` |
+| Web UI        | Served                | Blocked                                                  |
+| WebSocket     | Enabled               | Disabled                                                 |
+| `/simulate`   | IAP auth              | API auth                                                 |
+| `/microsites` | Blocked               | API auth                                                 |
+
+Local testing:
+
+```bash
+RUNTIME_CONTEXT=npc-ui npm run local    # UI context (default)
+RUNTIME_CONTEXT=npc-api NODE_ENV=dev node server.js  # API context
+```
+
+### Deployment Files
+
+| File                           | Purpose                          |
+| ------------------------------ | -------------------------------- |
+| `cloudbuild.yaml`              | UI service (private)             |
+| `cloudbuild-api.yaml`          | API service (public)             |
+| `.github/workflows/deploy.yml` | CI/CD: builds once, deploys both |
+| `scripts/deploy-all.sh`        | Manual deploy both               |
+
+## Sequences API
+
+`POST /simulate` supports deterministic sequences for reproducible user journeys. Key concepts:
+
+- **temperature** (0-10): adherence to sequence (0=random, 10=strict)
+- **chaos-range** `[min, max]`: multiplier on temperature for run-to-run variability
+- **actions**: array of `{action, selector, text?, value?}` — supports `click`, `type`, `select`
+- Multiple sequences distribute evenly among users
+
+See `meeple/sequences.js` for execution logic and `server.js` for validation.
+
+## Environment
+
+Required in `.env`:
+
+- `SERVICE_NAME`, `MIXPANEL_TOKEN`
+- `NODE_ENV` — `dev` | `production` | `test`
+- `RUNTIME_CONTEXT` — `npc-ui` | `npc-api`
+
+## Limits
+
+- Max 25 users/simulation, max 10 concurrent
+- 10-min timeout per session, 1-min page load timeout
+- Cloud Run: 8Gi memory, 4 CPU, 3600s timeout, 0-10 instances
+
+## Known Issues
+
+- **Typecheck fails** — 6 TS errors in `forms.js` (ElementHandle<Node> vs ElementHandle<Element>) and 1 unused var in `interactions.js`. Pre-existing, not blocking lint or tests.
+- `meeple/sequences.js` uses `@ts-nocheck` to suppress DOM/type complexity

--- a/README.md
+++ b/README.md
@@ -77,27 +77,27 @@ The web interface provides an intuitive way to configure and monitor your simula
 ### Programmatic Access
 
 ```javascript
-import main from "./headless.js";
+import main from './headless.js';
 
 // Basic simulation
 const results = await main({
-  url: "https://your-website.com",
-  users: 10,
-  concurrency: 3,
-  headless: true,
-  inject: true,
+	url: 'https://your-website.com',
+	users: 10,
+	concurrency: 3,
+	headless: true,
+	inject: true
 });
 
 // Advanced configuration
 const results = await main({
-  url: "https://your-website.com",
-  users: 15,
-  concurrency: 5,
-  headless: false, // Watch the automation
-  inject: true, // Inject Mixpanel tracking
-  past: true, // Use historical timestamps
-  token: "your_token", // Custom Mixpanel token
-  maxActions: 20, // Limit actions per user
+	url: 'https://your-website.com',
+	users: 15,
+	concurrency: 5,
+	headless: false, // Watch the automation
+	inject: true, // Inject Mixpanel tracking
+	past: true, // Use historical timestamps
+	token: 'your_token', // Custom Mixpanel token
+	maxActions: 20 // Limit actions per user
 });
 ```
 
@@ -195,8 +195,8 @@ Adds run-to-run variability by multiplying temperature by a random value:
 
 ```json
 {
-  "temperature": 5,
-  "chaos-range": [0.5, 1.5]
+	"temperature": 5,
+	"chaos-range": [0.5, 1.5]
 }
 ```
 
@@ -224,11 +224,11 @@ Clicks on an element identified by CSS selector:
 
 ```json
 {
-  "action": "click",
-  "selector": "#submit-btn",
-  "requireActive": true, // Skip if element is disabled or inactive
-  "expectsNavigation": true, // Wait for page navigation after click
-  "navigationTimeout": 5000 // Max wait time for navigation (ms)
+	"action": "click",
+	"selector": "#submit-btn",
+	"requireActive": true, // Skip if element is disabled or inactive
+	"expectsNavigation": true, // Wait for page navigation after click
+	"navigationTimeout": 5000 // Max wait time for navigation (ms)
 }
 ```
 
@@ -272,9 +272,9 @@ The `requireActive` flag allows you to skip actions when elements are disabled, 
 
 ```json
 {
-  "action": "click",
-  "selector": "#optional-button",
-  "requireActive": true
+	"action": "click",
+	"selector": "#optional-button",
+	"requireActive": true
 }
 ```
 
@@ -297,10 +297,10 @@ Indicates that an action will trigger page navigation:
 
 ```json
 {
-  "action": "click",
-  "selector": "#next-page",
-  "expectsNavigation": true,
-  "navigationTimeout": 10000
+	"action": "click",
+	"selector": "#next-page",
+	"expectsNavigation": true,
+	"navigationTimeout": 10000
 }
 ```
 
@@ -407,14 +407,14 @@ Action results include detailed error information:
 
 ```json
 {
-  "action": "click",
-  "selector": "#missing-element",
-  "success": false,
-  "error": "Element not found: #missing-element",
-  "reason": "selector_not_found",
-  "page_url": "https://example.com/page",
-  "duration": 5234,
-  "timestamp": 1711543267890
+	"action": "click",
+	"selector": "#missing-element",
+	"success": false,
+	"error": "Element not found: #missing-element",
+	"reason": "selector_not_found",
+	"page_url": "https://example.com/page",
+	"duration": 5234,
+	"timestamp": 1711543267890
 }
 ```
 
@@ -432,58 +432,58 @@ Here's a comprehensive example using all the new features:
 
 ```json
 {
-  "url": "https://your-ecommerce-site.com",
-  "users": 5,
-  "sequences": {
-    "complete-purchase-flow": {
-      "description": "Full checkout funnel with error handling",
-      "temperature": 8,
-      "chaos-range": [0.8, 1.2],
-      "debug": false,
-      "circuitBreaker": {
-        "maxFailures": 5,
-        "resetOnSuccess": true,
-        "mode": "skip"
-      },
-      "actions": [
-        {
-          "action": "click",
-          "selector": "[data-testid='product-card']",
-          "requireActive": true
-        },
-        {
-          "action": "click",
-          "selector": "#add-to-cart"
-        },
-        {
-          "action": "click",
-          "selector": "#optional-upsell",
-          "requireActive": true
-        },
-        {
-          "action": "click",
-          "selector": "#checkout-button",
-          "expectsNavigation": true,
-          "navigationTimeout": 10000
-        },
-        {
-          "action": "type",
-          "selector": "#email",
-          "text": "customer@example.com"
-        },
-        {
-          "action": "type",
-          "selector": "#card-number",
-          "text": "4111111111111111"
-        },
-        {
-          "action": "click",
-          "selector": "#complete-order",
-          "expectsNavigation": true
-        }
-      ]
-    }
-  }
+	"url": "https://your-ecommerce-site.com",
+	"users": 5,
+	"sequences": {
+		"complete-purchase-flow": {
+			"description": "Full checkout funnel with error handling",
+			"temperature": 8,
+			"chaos-range": [0.8, 1.2],
+			"debug": false,
+			"circuitBreaker": {
+				"maxFailures": 5,
+				"resetOnSuccess": true,
+				"mode": "skip"
+			},
+			"actions": [
+				{
+					"action": "click",
+					"selector": "[data-testid='product-card']",
+					"requireActive": true
+				},
+				{
+					"action": "click",
+					"selector": "#add-to-cart"
+				},
+				{
+					"action": "click",
+					"selector": "#optional-upsell",
+					"requireActive": true
+				},
+				{
+					"action": "click",
+					"selector": "#checkout-button",
+					"expectsNavigation": true,
+					"navigationTimeout": 10000
+				},
+				{
+					"action": "type",
+					"selector": "#email",
+					"text": "customer@example.com"
+				},
+				{
+					"action": "type",
+					"selector": "#card-number",
+					"text": "4111111111111111"
+				},
+				{
+					"action": "click",
+					"selector": "#complete-order",
+					"expectsNavigation": true
+				}
+			]
+		}
+	}
 }
 ```
 
@@ -501,35 +501,35 @@ Here's a comprehensive example using all the new features:
 
 ```json
 {
-  "sequences": {
-    "abandoned-cart": {
-      "description": "Add to cart but abandon checkout",
-      "temperature": 6,
-      "chaos-range": [1, 3],
-      "actions": [
-        { "action": "click", "selector": ".product-item" },
-        { "action": "click", "selector": "#add-to-cart" },
-        { "action": "click", "selector": "#cart-icon" },
-        { "action": "click", "selector": "#remove-item" }
-      ]
-    },
-    "successful-purchase": {
-      "description": "Complete full purchase flow",
-      "temperature": 8,
-      "actions": [
-        { "action": "click", "selector": ".product-item" },
-        { "action": "click", "selector": "#add-to-cart" },
-        { "action": "click", "selector": "#checkout" },
-        {
-          "action": "type",
-          "selector": "#email",
-          "text": "customer@example.com"
-        },
-        { "action": "type", "selector": "#card", "text": "4111111111111111" },
-        { "action": "click", "selector": "#complete-order" }
-      ]
-    }
-  }
+	"sequences": {
+		"abandoned-cart": {
+			"description": "Add to cart but abandon checkout",
+			"temperature": 6,
+			"chaos-range": [1, 3],
+			"actions": [
+				{ "action": "click", "selector": ".product-item" },
+				{ "action": "click", "selector": "#add-to-cart" },
+				{ "action": "click", "selector": "#cart-icon" },
+				{ "action": "click", "selector": "#remove-item" }
+			]
+		},
+		"successful-purchase": {
+			"description": "Complete full purchase flow",
+			"temperature": 8,
+			"actions": [
+				{ "action": "click", "selector": ".product-item" },
+				{ "action": "click", "selector": "#add-to-cart" },
+				{ "action": "click", "selector": "#checkout" },
+				{
+					"action": "type",
+					"selector": "#email",
+					"text": "customer@example.com"
+				},
+				{ "action": "type", "selector": "#card", "text": "4111111111111111" },
+				{ "action": "click", "selector": "#complete-order" }
+			]
+		}
+	}
 }
 ```
 
@@ -537,29 +537,29 @@ Here's a comprehensive example using all the new features:
 
 ```json
 {
-  "sequences": {
-    "invalid-email-flow": {
-      "description": "Test email validation",
-      "temperature": 9,
-      "actions": [
-        { "action": "type", "selector": "#email", "text": "invalid-email" },
-        { "action": "click", "selector": "#submit" },
-        { "action": "type", "selector": "#email", "text": "valid@example.com" },
-        { "action": "click", "selector": "#submit" }
-      ]
-    },
-    "required-fields": {
-      "description": "Test required field validation",
-      "temperature": 8,
-      "actions": [
-        { "action": "click", "selector": "#submit" },
-        { "action": "type", "selector": "#name", "text": "John Doe" },
-        { "action": "click", "selector": "#submit" },
-        { "action": "type", "selector": "#email", "text": "john@example.com" },
-        { "action": "click", "selector": "#submit" }
-      ]
-    }
-  }
+	"sequences": {
+		"invalid-email-flow": {
+			"description": "Test email validation",
+			"temperature": 9,
+			"actions": [
+				{ "action": "type", "selector": "#email", "text": "invalid-email" },
+				{ "action": "click", "selector": "#submit" },
+				{ "action": "type", "selector": "#email", "text": "valid@example.com" },
+				{ "action": "click", "selector": "#submit" }
+			]
+		},
+		"required-fields": {
+			"description": "Test required field validation",
+			"temperature": 8,
+			"actions": [
+				{ "action": "click", "selector": "#submit" },
+				{ "action": "type", "selector": "#name", "text": "John Doe" },
+				{ "action": "click", "selector": "#submit" },
+				{ "action": "type", "selector": "#email", "text": "john@example.com" },
+				{ "action": "click", "selector": "#submit" }
+			]
+		}
+	}
 }
 ```
 
@@ -567,29 +567,29 @@ Here's a comprehensive example using all the new features:
 
 ```json
 {
-  "sequences": {
-    "variant-a-flow": {
-      "description": "Test variant A of signup flow",
-      "temperature": 7,
-      "actions": [
-        { "action": "click", "selector": "#signup-variant-a" },
-        { "action": "type", "selector": "#email", "text": "test@example.com" },
-        { "action": "type", "selector": "#password", "text": "password123" },
-        { "action": "click", "selector": "#create-account" }
-      ]
-    },
-    "variant-b-flow": {
-      "description": "Test variant B of signup flow",
-      "temperature": 7,
-      "actions": [
-        { "action": "click", "selector": "#signup-variant-b" },
-        { "action": "type", "selector": "#username", "text": "testuser" },
-        { "action": "type", "selector": "#email", "text": "test@example.com" },
-        { "action": "type", "selector": "#password", "text": "password123" },
-        { "action": "click", "selector": "#register" }
-      ]
-    }
-  }
+	"sequences": {
+		"variant-a-flow": {
+			"description": "Test variant A of signup flow",
+			"temperature": 7,
+			"actions": [
+				{ "action": "click", "selector": "#signup-variant-a" },
+				{ "action": "type", "selector": "#email", "text": "test@example.com" },
+				{ "action": "type", "selector": "#password", "text": "password123" },
+				{ "action": "click", "selector": "#create-account" }
+			]
+		},
+		"variant-b-flow": {
+			"description": "Test variant B of signup flow",
+			"temperature": 7,
+			"actions": [
+				{ "action": "click", "selector": "#signup-variant-b" },
+				{ "action": "type", "selector": "#username", "text": "testuser" },
+				{ "action": "type", "selector": "#email", "text": "test@example.com" },
+				{ "action": "type", "selector": "#password", "text": "password123" },
+				{ "action": "click", "selector": "#register" }
+			]
+		}
+	}
 }
 ```
 
@@ -599,35 +599,35 @@ Successful execution returns detailed results:
 
 ```json
 {
-  "results": [
-    {
-      "actions": [
-        {
-          "action": "click",
-          "selector": "#product",
-          "success": true,
-          "duration": 245,
-          "timestamp": 1647891234567,
-          "page_url": "https://example.com/products"
-        },
-        {
-          "action": "type",
-          "selector": "#email",
-          "text": "user@example.com",
-          "success": true,
-          "duration": 180,
-          "timestamp": 1647891234812,
-          "page_url": "https://example.com/checkout"
-        }
-      ],
-      "duration": 12,
-      "persona": "researcher",
-      "sequence": "checkout-flow",
-      "success": true,
-      "circuit_breaker_triggered": false,
-      "failed_actions": []
-    }
-  ]
+	"results": [
+		{
+			"actions": [
+				{
+					"action": "click",
+					"selector": "#product",
+					"success": true,
+					"duration": 245,
+					"timestamp": 1647891234567,
+					"page_url": "https://example.com/products"
+				},
+				{
+					"action": "type",
+					"selector": "#email",
+					"text": "user@example.com",
+					"success": true,
+					"duration": 180,
+					"timestamp": 1647891234812,
+					"page_url": "https://example.com/checkout"
+				}
+			],
+			"duration": 12,
+			"persona": "researcher",
+			"sequence": "checkout-flow",
+			"success": true,
+			"circuit_breaker_triggered": false,
+			"failed_actions": []
+		}
+	]
 }
 ```
 
@@ -661,12 +661,12 @@ Invalid sequences return detailed error messages:
 
 ```json
 {
-  "error": "Invalid sequences specification",
-  "details": [
-    "Sequence \"test\": Temperature must be a number between 0 and 10",
-    "Sequence \"test\": Action 1 has unsupported action type: invalid",
-    "Sequence \"test\": Action 2 (type) must have a text field"
-  ]
+	"error": "Invalid sequences specification",
+	"details": [
+		"Sequence \"test\": Temperature must be a number between 0 and 10",
+		"Sequence \"test\": Action 1 has unsupported action type: invalid",
+		"Sequence \"test\": Action 2 (type) must have a text field"
+	]
 }
 ```
 
@@ -722,15 +722,15 @@ When using sequences with Mixpanel Session Replay, be aware of buffer timing:
 
 ```json
 {
-  "actions": [
-    { "action": "click", "selector": "#page1-button" },
-    { "action": "wait", "duration": 10000 }, // Wait for buffer flush
-    {
-      "action": "click",
-      "selector": "#page2-button",
-      "expectsNavigation": true
-    }
-  ]
+	"actions": [
+		{ "action": "click", "selector": "#page1-button" },
+		{ "action": "wait", "duration": 10000 }, // Wait for buffer flush
+		{
+			"action": "click",
+			"selector": "#page2-button",
+			"expectsNavigation": true
+		}
+	]
 }
 ```
 
@@ -739,8 +739,8 @@ When using sequences with Mixpanel Session Replay, be aware of buffer timing:
 ```javascript
 // After sequence execution
 await page.evaluate(() => {
-  // Wait 10+ seconds for Mixpanel buffer to flush
-  return new Promise((resolve) => setTimeout(resolve, 10000));
+	// Wait 10+ seconds for Mixpanel buffer to flush
+	return new Promise(resolve => setTimeout(resolve, 10000));
 });
 ```
 
@@ -748,10 +748,10 @@ await page.evaluate(() => {
 
 ```javascript
 await page.evaluate(() => {
-  if (window.mixpanel?.persistence?.props?.__mps) {
-    // Force replay data flush
-    window.mixpanel.persistence.save();
-  }
+	if (window.mixpanel?.persistence?.props?.__mps) {
+		// Force replay data flush
+		window.mixpanel.persistence.save();
+	}
 });
 ```
 
@@ -833,17 +833,17 @@ Enable detailed logging by checking browser console for:
 Full TypeScript definitions are available in `index.d.ts`:
 
 ```typescript
-import { SequenceSpec, MeepleParams } from "./index";
+import { SequenceSpec, MeepleParams } from './index';
 
 const sequence: SequenceSpec = {
-  description: "Test sequence",
-  temperature: 7,
-  actions: [{ action: "click", selector: "#button" }],
+	description: 'Test sequence',
+	temperature: 7,
+	actions: [{ action: 'click', selector: '#button' }]
 };
 
 const params: MeepleParams = {
-  url: "https://example.com",
-  users: 5,
-  sequences: { test: sequence },
+	url: 'https://example.com',
+	users: 5,
+	sequences: { test: sequence }
 };
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,412 +5,405 @@
 
 // Global type augmentations for browser context
 declare global {
-  // Mixpanel library types
-  interface Mixpanel {
-    init(token: string, config?: any, name?: string): void;
-    track(event: string, properties?: any): void;
-    identify(id: string): void;
-    people: {
-      set(properties: any): void;
-      set_once(properties: any): void;
-      increment(property: string, by?: number): void;
-    };
-    register(properties: any): void;
-    reset(): void;
-    headless?: {
-      reset(): void;
-    };
-    __SV?: number;
-    _i?: any[];
-  }
+	// Mixpanel library types
+	interface Mixpanel {
+		init(token: string, config?: any, name?: string): void;
+		track(event: string, properties?: any): void;
+		identify(id: string): void;
+		people: {
+			set(properties: any): void;
+			set_once(properties: any): void;
+			increment(property: string, by?: number): void;
+		};
+		register(properties: any): void;
+		reset(): void;
+		headless?: {
+			reset(): void;
+		};
+		__SV?: number;
+		_i?: any[];
+	}
 
-  // Window object augmentations for Puppeteer page context
-  interface Window {
-    mixpanel?: Mixpanel | any[];
-    MIXPANEL_WAS_INJECTED?: boolean;
-    MIXPANEL_INJECTED_TIMESTAMP?: number;
-    MIXPANEL_INJECTION_SUCCESS?: boolean;
-    MIXPANEL_CUSTOM_LIB_URL?: string;
-    trustedTypes?: {
-      createPolicy(name: string, policy: any): any;
-      getPolicy(name: string): any;
-      getPolicyNames(): string[];
-      defaultPolicy?: any;
-    };
-    // CSP (Content Security Policy) bypass properties
-    CSP_RELAXED?: boolean;
-    CSP_WAS_RELAXED?: boolean;
-    CSP_RELAXED_TIMESTAMP?: number;
-    CSP_EVAL_WORKING?: boolean;
-    TRUSTED_TYPES_BYPASS?: boolean;
-    originalEval?: typeof eval;
-    // Mouse tracking properties used by interactions.js
-    mouseX?: number;
-    mouseY?: number;
-  }
+	// Window object augmentations for Puppeteer page context
+	interface Window {
+		mixpanel?: Mixpanel | any[];
+		MIXPANEL_WAS_INJECTED?: boolean;
+		MIXPANEL_INJECTED_TIMESTAMP?: number;
+		MIXPANEL_INJECTION_SUCCESS?: boolean;
+		MIXPANEL_CUSTOM_LIB_URL?: string;
+		trustedTypes?: {
+			createPolicy(name: string, policy: any): any;
+			getPolicy(name: string): any;
+			getPolicyNames(): string[];
+			defaultPolicy?: any;
+		};
+		// CSP (Content Security Policy) bypass properties
+		CSP_RELAXED?: boolean;
+		CSP_WAS_RELAXED?: boolean;
+		CSP_RELAXED_TIMESTAMP?: number;
+		CSP_EVAL_WORKING?: boolean;
+		TRUSTED_TYPES_BYPASS?: boolean;
+		originalEval?: typeof eval;
+		// Mouse tracking properties used by interactions.js
+		mouseX?: number;
+		mouseY?: number;
+	}
 
-  // Global mixpanel variable (for non-window contexts)
-  var mixpanel: Mixpanel | undefined;
+	// Global mixpanel variable (for non-window contexts)
+	var mixpanel: Mixpanel | undefined;
 
-  // Socket.IO global (loaded from CDN in browser)
-  function io(opts?: any): any;
+	// Socket.IO global (loaded from CDN in browser)
+	function io(opts?: any): any;
 }
 
 // Puppeteer Page type augmentations
-declare module "puppeteer" {
-  interface Page {
-    MIXPANEL_TOKEN?: string;
-  }
+declare module 'puppeteer' {
+	interface Page {
+		MIXPANEL_TOKEN?: string;
+	}
 
-  // ElementHandle augmentation for non-standard browser methods
-  interface ElementHandle {
-    scrollIntoViewIfNeeded?(options?: any): Promise<void>;
-  }
+	// ElementHandle augmentation for non-standard browser methods
+	interface ElementHandle {
+		scrollIntoViewIfNeeded?(options?: any): Promise<void>;
+	}
 }
 
 // Browser DOM augmentations for form elements in page.evaluate() contexts
 // These are the actual runtime types when manipulating DOM elements
 declare global {
-  // Extend Element to include common form element properties
-  // This allows TypeScript to understand that elements in page.evaluate() have these properties
-  interface Element {
-    // HTMLInputElement / HTMLTextAreaElement properties
-    type?: string;
-    value?: string;
-    placeholder?: string;
-    name?: string;
-    disabled?: boolean;
-    readOnly?: boolean;
-    checked?: boolean;
+	// Extend Element to include common form element properties
+	// This allows TypeScript to understand that elements in page.evaluate() have these properties
+	interface Element {
+		// HTMLInputElement / HTMLTextAreaElement properties
+		type?: string;
+		value?: string;
+		placeholder?: string;
+		name?: string;
+		disabled?: boolean;
+		readOnly?: boolean;
+		checked?: boolean;
 
-    // HTMLSelectElement properties
-    options?: HTMLOptionsCollection;
-    selectedIndex?: number;
+		// HTMLSelectElement properties
+		options?: HTMLOptionsCollection;
+		selectedIndex?: number;
 
-    // HTMLElement offset properties (for positioning/layout)
-    offsetTop?: number;
-    offsetLeft?: number;
-    offsetWidth?: number;
-    offsetHeight?: number;
+		// HTMLElement offset properties (for positioning/layout)
+		offsetTop?: number;
+		offsetLeft?: number;
+		offsetWidth?: number;
+		offsetHeight?: number;
 
-    // HTMLElement visibility properties
-    hidden?: boolean;
+		// HTMLElement visibility properties
+		hidden?: boolean;
 
-    // CSSStyleDeclaration for style property
-    style?: CSSStyleDeclaration;
-  }
+		// CSSStyleDeclaration for style property
+		style?: CSSStyleDeclaration;
+	}
 }
 
 export interface MeepleParams {
-  /** Target URL to simulate user behavior on */
-  url?: string;
-  /** Number of concurrent users to simulate (max 25) */
-  users?: number;
-  /** Concurrency limit for simultaneous executions (max 10) */
-  concurrency?: number;
-  /** Run browser in headless mode */
-  headless?: boolean;
-  /** Inject Mixpanel analytics tracking */
-  inject?: boolean;
-  /** Simulate past timestamps for analytics */
-  past?: boolean;
-  /** Mixpanel token override */
-  token?: string;
-  /** Maximum actions per user session */
-  maxActions?: number | null;
-  /** Enable element masking for privacy */
-  masking?: boolean;
-  /** Deterministic sequences specification */
-  sequences?: SequencesSpec | null;
-  /** Unique identifier for this simulation run */
-  runId?: string;
+	/** Target URL to simulate user behavior on */
+	url?: string;
+	/** Number of concurrent users to simulate (max 25) */
+	users?: number;
+	/** Concurrency limit for simultaneous executions (max 10) */
+	concurrency?: number;
+	/** Run browser in headless mode */
+	headless?: boolean;
+	/** Inject Mixpanel analytics tracking */
+	inject?: boolean;
+	/** Simulate past timestamps for analytics */
+	past?: boolean;
+	/** Mixpanel token override */
+	token?: string;
+	/** Maximum actions per user session */
+	maxActions?: number | null;
+	/** Enable element masking for privacy */
+	masking?: boolean;
+	/** Deterministic sequences specification */
+	sequences?: SequencesSpec | null;
+	/** Unique identifier for this simulation run */
+	runId?: string;
 
-  // ── Friction Behaviors ──
+	// ── Friction Behaviors ──
 
-  /** Simulate poor network conditions via CDP throttling */
-  networkProfile?: "fast" | "moderate" | "slow3g" | "slow4g" | "offline";
-  /** Enable Chaos Mode: randomly sabotage POST/PUT/PATCH requests + dead clicks */
-  chaosMode?: boolean;
-  /** Probability (0-1) that a data request will fail in chaos mode. Default: 0.15 */
-  chaosFailRate?: number;
-  /** Enable intentional form mistakes: meeples submit wrong data, trigger validation, then correct */
-  formMistakes?: boolean;
-  /** Client identifier for tracking which service triggered the job (e.g. 'powertools-ui', 'mpTweaks') */
-  client_id?: string;
+	/** Simulate poor network conditions via CDP throttling */
+	networkProfile?: 'fast' | 'moderate' | 'slow3g' | 'slow4g' | 'offline';
+	/** Enable Chaos Mode: randomly sabotage POST/PUT/PATCH requests + dead clicks */
+	chaosMode?: boolean;
+	/** Probability (0-1) that a data request will fail in chaos mode. Default: 0.15 */
+	chaosFailRate?: number;
+	/** Enable intentional form mistakes: meeples submit wrong data, trigger validation, then correct */
+	formMistakes?: boolean;
+	/** Client identifier for tracking which service triggered the job (e.g. 'powertools-ui', 'mpTweaks') */
+	client_id?: string;
 }
 
 export interface SequencesSpec {
-  [sequenceName: string]: SequenceSpec;
+	[sequenceName: string]: SequenceSpec;
 }
 
 export interface SequenceSpec {
-  /** Human-readable description of the sequence */
-  description?: string;
-  /**
-   * How strictly to follow the sequence (0-10)
-   * 0 = completely random actions
-   * 10 = strictly follow the defined sequence
-   */
-  temperature?: number;
-  /**
-   * Random multiplier range applied to temperature
-   * [min, max] values to introduce run-to-run variability
-   */
-  "chaos-range"?: [number, number];
-  /** Array of actions to perform in sequence */
-  actions: SequenceAction[];
-  /**
-   * Circuit breaker configuration for handling failures
-   * Controls how the sequence responds to consecutive failures
-   */
-  circuitBreaker?: CircuitBreakerConfig;
-  /**
-   * Enable debug mode for verbose logging
-   * Outputs detailed information about selector matching, element states, and timing
-   */
-  debug?: boolean;
+	/** Human-readable description of the sequence */
+	description?: string;
+	/**
+	 * How strictly to follow the sequence (0-10)
+	 * 0 = completely random actions
+	 * 10 = strictly follow the defined sequence
+	 */
+	temperature?: number;
+	/**
+	 * Random multiplier range applied to temperature
+	 * [min, max] values to introduce run-to-run variability
+	 */
+	'chaos-range'?: [number, number];
+	/** Array of actions to perform in sequence */
+	actions: SequenceAction[];
+	/**
+	 * Circuit breaker configuration for handling failures
+	 * Controls how the sequence responds to consecutive failures
+	 */
+	circuitBreaker?: CircuitBreakerConfig;
+	/**
+	 * Enable debug mode for verbose logging
+	 * Outputs detailed information about selector matching, element states, and timing
+	 */
+	debug?: boolean;
 }
 
 export interface CircuitBreakerConfig {
-  /**
-   * Maximum number of consecutive failures before stopping the sequence
-   * Default: 3
-   * Recommendation: 5+ for production use with dynamic content
-   */
-  maxFailures?: number;
-  /**
-   * Whether to reset the failure counter after a successful action
-   * Default: true
-   */
-  resetOnSuccess?: boolean;
-  /**
-   * Circuit breaker behavior mode
-   * - 'terminate': Stop the entire sequence after maxFailures (default)
-   * - 'skip': Skip failed actions and continue with remaining actions
-   */
-  mode?: "terminate" | "skip";
+	/**
+	 * Maximum number of consecutive failures before stopping the sequence
+	 * Default: 3
+	 * Recommendation: 5+ for production use with dynamic content
+	 */
+	maxFailures?: number;
+	/**
+	 * Whether to reset the failure counter after a successful action
+	 * Default: true
+	 */
+	resetOnSuccess?: boolean;
+	/**
+	 * Circuit breaker behavior mode
+	 * - 'terminate': Stop the entire sequence after maxFailures (default)
+	 * - 'skip': Skip failed actions and continue with remaining actions
+	 */
+	mode?: 'terminate' | 'skip';
 }
 
 export type SequenceAction = ClickAction | TypeAction | SelectAction;
 
 export interface BaseAction {
-  /** CSS selector for the target element */
-  selector: string;
-  /**
-   * If true, skip this action if the element is disabled, inactive, or not found
-   * Does NOT count as a failure for circuit breaker purposes
-   * Useful for optional UI elements that may not always be present
-   */
-  requireActive?: boolean;
-  /**
-   * If true, indicates this action triggers page navigation
-   * The system will wait for the new page to load before continuing
-   */
-  expectsNavigation?: boolean;
-  /**
-   * Maximum time to wait for navigation to complete (milliseconds)
-   * Only applies when expectsNavigation is true
-   * Default: 5000
-   */
-  navigationTimeout?: number;
+	/** CSS selector for the target element */
+	selector: string;
+	/**
+	 * If true, skip this action if the element is disabled, inactive, or not found
+	 * Does NOT count as a failure for circuit breaker purposes
+	 * Useful for optional UI elements that may not always be present
+	 */
+	requireActive?: boolean;
+	/**
+	 * If true, indicates this action triggers page navigation
+	 * The system will wait for the new page to load before continuing
+	 */
+	expectsNavigation?: boolean;
+	/**
+	 * Maximum time to wait for navigation to complete (milliseconds)
+	 * Only applies when expectsNavigation is true
+	 * Default: 5000
+	 */
+	navigationTimeout?: number;
 }
 
 export interface ClickAction extends BaseAction {
-  action: "click";
+	action: 'click';
 }
 
 export interface TypeAction extends BaseAction {
-  action: "type";
-  /** Text to type into the element */
-  text: string;
+	action: 'type';
+	/** Text to type into the element */
+	text: string;
 }
 
 export interface SelectAction extends BaseAction {
-  action: "select";
-  /** Value to select from dropdown */
-  value: string;
+	action: 'select';
+	/** Value to select from dropdown */
+	value: string;
 }
 
 export interface SequenceActionResult {
-  /** Type of action performed */
-  action: string;
-  /** CSS selector used */
-  selector: string;
-  /** Text typed (for type actions) */
-  text?: string;
-  /** Value selected (for select actions) */
-  value?: string;
-  /** Whether the action succeeded */
-  success: boolean;
-  /** Whether the action was skipped due to requireActive flag */
-  skipped?: boolean;
-  /** Error message if action failed */
-  error?: string;
-  /** Specific reason for failure (e.g., 'selector_not_found', 'element_not_visible', 'timeout') */
-  reason?: string;
-  /** Duration of action execution in milliseconds */
-  duration: number;
-  /** Timestamp when action was executed */
-  timestamp: number;
-  /** Current page URL when action was attempted */
-  page_url?: string;
+	/** Type of action performed */
+	action: string;
+	/** CSS selector used */
+	selector: string;
+	/** Text typed (for type actions) */
+	text?: string;
+	/** Value selected (for select actions) */
+	value?: string;
+	/** Whether the action succeeded */
+	success: boolean;
+	/** Whether the action was skipped due to requireActive flag */
+	skipped?: boolean;
+	/** Error message if action failed */
+	error?: string;
+	/** Specific reason for failure (e.g., 'selector_not_found', 'element_not_visible', 'timeout') */
+	reason?: string;
+	/** Duration of action execution in milliseconds */
+	duration: number;
+	/** Timestamp when action was executed */
+	timestamp: number;
+	/** Current page URL when action was attempted */
+	page_url?: string;
 }
 
 export interface ValidationResult {
-  /** Whether the validation passed */
-  valid: boolean;
-  /** Array of validation error messages */
-  errors: string[];
+	/** Whether the validation passed */
+	valid: boolean;
+	/** Array of validation error messages */
+	errors: string[];
 }
 
 export interface SimulationResult {
-  /** Array of actions performed by the meeple */
-  actions: SequenceActionResult[];
-  /** Duration of the session in seconds */
-  duration: number;
-  /** Persona used for random actions */
-  persona: string;
-  /** Name of sequence used (if any) */
-  sequence?: string | null;
-  /** Whether the simulation completed successfully */
-  success: boolean;
-  /** Error message if simulation failed */
-  error?: string;
-  /** Whether the simulation timed out */
-  timedOut?: boolean;
-  /** Whether the simulation crashed */
-  crashed?: boolean;
-  /** Whether the circuit breaker was triggered during sequence execution */
-  circuit_breaker_triggered?: boolean;
-  /** Array of failed actions with detailed error information */
-  failed_actions?: SequenceActionResult[];
+	/** Array of actions performed by the meeple */
+	actions: SequenceActionResult[];
+	/** Duration of the session in seconds */
+	duration: number;
+	/** Persona used for random actions */
+	persona: string;
+	/** Name of sequence used (if any) */
+	sequence?: string | null;
+	/** Whether the simulation completed successfully */
+	success: boolean;
+	/** Error message if simulation failed */
+	error?: string;
+	/** Whether the simulation timed out */
+	timedOut?: boolean;
+	/** Whether the simulation crashed */
+	crashed?: boolean;
+	/** Whether the circuit breaker was triggered during sequence execution */
+	circuit_breaker_triggered?: boolean;
+	/** Array of failed actions with detailed error information */
+	failed_actions?: SequenceActionResult[];
 }
 
 export interface HotZone {
-  /** X coordinate of the hot zone */
-  x: number;
-  /** Y coordinate of the hot zone */
-  y: number;
-  /** Width of the hot zone */
-  width: number;
-  /** Height of the hot zone */
-  height: number;
-  /** Priority score (higher = more important) */
-  priority: number;
-  /** HTML tag name */
-  tag: string;
-  /** Text content of the element */
-  text: string;
-  /** CSS selector for the element */
-  selector?: string;
+	/** X coordinate of the hot zone */
+	x: number;
+	/** Y coordinate of the hot zone */
+	y: number;
+	/** Width of the hot zone */
+	width: number;
+	/** Height of the hot zone */
+	height: number;
+	/** Priority score (higher = more important) */
+	priority: number;
+	/** HTML tag name */
+	tag: string;
+	/** Text content of the element */
+	text: string;
+	/** CSS selector for the element */
+	selector?: string;
 }
 
 export interface MeepleLocation {
-  /** Latitude coordinate */
-  lat: number;
-  /** Longitude coordinate */
-  lon: number;
+	/** Latitude coordinate */
+	lat: number;
+	/** Longitude coordinate */
+	lon: number;
 }
 
 export interface MeepleOptions {
-  /** Enable element masking for privacy */
-  masking?: boolean;
-  /** Geographic location for the meeple */
-  location?: MeepleLocation;
-  /** Sequence specification for deterministic behavior */
-  sequence?: SequenceSpec;
-  /** Name of the assigned sequence */
-  sequenceName?: string;
+	/** Enable element masking for privacy */
+	masking?: boolean;
+	/** Geographic location for the meeple */
+	location?: MeepleLocation;
+	/** Sequence specification for deterministic behavior */
+	sequence?: SequenceSpec;
+	/** Name of the assigned sequence */
+	sequenceName?: string;
 
-  // ── Friction Behaviors ──
+	// ── Friction Behaviors ──
 
-  /** Network throttling profile */
-  networkProfile?: "fast" | "moderate" | "slow3g" | "slow4g" | "offline";
-  /** Enable Chaos Mode */
-  chaosMode?: boolean;
-  /** Chaos mode fail rate (0-1) */
-  chaosFailRate?: number;
-  /** Enable intentional form mistakes */
-  formMistakes?: boolean;
+	/** Network throttling profile */
+	networkProfile?: 'fast' | 'moderate' | 'slow3g' | 'slow4g' | 'offline';
+	/** Enable Chaos Mode */
+	chaosMode?: boolean;
+	/** Chaos mode fail rate (0-1) */
+	chaosFailRate?: number;
+	/** Enable intentional form mistakes */
+	formMistakes?: boolean;
 }
 
 export type LogFunction = (message: string, meepleId?: string | null) => void;
 
 export type PersonaType =
-  | "quickBrowser"
-  | "researcher"
-  | "shopper"
-  | "explorer"
-  | "powerUser"
-  | "taskFocused"
-  | "methodical"
-  | "impulse"
-  | "reader"
-  | "skimmer"
-  | "discoverer"
-  | "comparison"
-  | "decisive"
-  | "rolePlayer"
-  | "minMaxer"
-  | "murderHobo"
-  | "ruleSlawyer"
-  | "mobileHabits";
+	| 'quickBrowser'
+	| 'researcher'
+	| 'shopper'
+	| 'explorer'
+	| 'powerUser'
+	| 'taskFocused'
+	| 'methodical'
+	| 'impulse'
+	| 'reader'
+	| 'skimmer'
+	| 'discoverer'
+	| 'comparison'
+	| 'decisive'
+	| 'rolePlayer'
+	| 'minMaxer'
+	| 'murderHobo'
+	| 'ruleSlawyer'
+	| 'mobileHabits';
 
 export interface ActionSequenceItem {
-  action: string;
-  weight?: number;
-  persona?: PersonaType;
+	action: string;
+	weight?: number;
+	persona?: PersonaType;
 }
 
 // Sequence execution functions
 export declare function executeSequence(
-  page: any, // Puppeteer Page type
-  sequenceSpec: SequenceSpec,
-  hotZones: HotZone[],
-  persona: PersonaType,
-  usersHandle: string,
-  opts: MeepleOptions,
-  log: LogFunction,
+	page: any, // Puppeteer Page type
+	sequenceSpec: SequenceSpec,
+	hotZones: HotZone[],
+	persona: PersonaType,
+	usersHandle: string,
+	opts: MeepleOptions,
+	log: LogFunction
 ): Promise<SequenceActionResult[]>;
 
-export declare function validateSequence(
-  sequenceSpec: SequenceSpec,
-): ValidationResult;
-export declare function validateSequences(
-  sequences: SequencesSpec,
-): ValidationResult;
+export declare function validateSequence(sequenceSpec: SequenceSpec): ValidationResult;
+export declare function validateSequences(sequences: SequencesSpec): ValidationResult;
 
 // Main simulation function
-export declare function main(
-  params: MeepleParams,
-  logFunction?: LogFunction,
-): Promise<SimulationResult[]>;
+export declare function main(params: MeepleParams, logFunction?: LogFunction): Promise<SimulationResult[]>;
 
 // Individual user simulation
 export declare function simulateUser(
-  url: string,
-  headless?: boolean,
-  inject?: boolean,
-  past?: boolean,
-  maxActions?: number | null,
-  usersHandle?: string | null,
-  opts?: MeepleOptions,
-  logFunction?: LogFunction,
+	url: string,
+	headless?: boolean,
+	inject?: boolean,
+	past?: boolean,
+	maxActions?: number | null,
+	usersHandle?: string | null,
+	opts?: MeepleOptions,
+	logFunction?: LogFunction
 ): Promise<SimulationResult>;
 
 // API Response types
 export interface SimulateResponse {
-  /** Array of simulation results for each meeple */
-  results?: SimulationResult[];
-  /** Error message if simulation failed */
-  error?: string;
-  /** Detailed error information for validation failures */
-  details?: string[];
+	/** Array of simulation results for each meeple */
+	results?: SimulationResult[];
+	/** Error message if simulation failed */
+	error?: string;
+	/** Detailed error information for validation failures */
+	details?: string[];
 }
 
 export interface ApiError {
-  /** High-level error message */
-  error: string;
-  /** Detailed error information */
-  details?: string[];
+	/** High-level error message */
+	error: string;
+	/** Detailed error information */
+	details?: string[];
 }

--- a/meeple/browser.js
+++ b/meeple/browser.js
@@ -175,7 +175,10 @@ export async function enableChaosMode(page, failRate = 0.15, log = console.log) 
 	try {
 		await page.setRequestInterception(true);
 		page.on('request', request => {
-			const isMixpanelRequest = request.url().includes('mixpanel') || request.url().includes('mxpnl') || request.url().includes('express-proxy-lmozz6xkha-uc.a.run.app');
+			const isMixpanelRequest =
+				request.url().includes('mixpanel') ||
+				request.url().includes('mxpnl') ||
+				request.url().includes('express-proxy-lmozz6xkha-uc.a.run.app');
 			const isDataRequest =
 				!isMixpanelRequest &&
 				['POST', 'PUT', 'PATCH'].includes(request.method()) &&
@@ -184,7 +187,9 @@ export async function enableChaosMode(page, failRate = 0.15, log = console.log) 
 			if (isDataRequest && Math.random() < failRate) {
 				const statusCode = Math.random() < 0.5 ? 500 : 503;
 				const errorMsg = statusCode === 500 ? 'Internal Server Error' : 'Service Unavailable';
-				log(`😈 <span style="color: #CC332B;">Chaos Meeple sabotaged:</span> ${request.method()} ${request.url().substring(0, 80)}`);
+				log(
+					`😈 <span style="color: #CC332B;">Chaos Meeple sabotaged:</span> ${request.method()} ${request.url().substring(0, 80)}`
+				);
 				request.respond({
 					status: statusCode,
 					contentType: 'application/json',
@@ -194,7 +199,9 @@ export async function enableChaosMode(page, failRate = 0.15, log = console.log) 
 				request.continue();
 			}
 		});
-		log(`😈 <span style="color: #FF7557;">Chaos Mode enabled</span> (${(failRate * 100).toFixed(0)}% fail rate on data requests)`);
+		log(
+			`😈 <span style="color: #FF7557;">Chaos Mode enabled</span> (${(failRate * 100).toFixed(0)}% fail rate on data requests)`
+		);
 	} catch (error) {
 		log(`⚠️ Chaos mode setup failed: ${error.message}`);
 	}
@@ -221,12 +228,12 @@ export async function createPage(browser, log = console.log) {
 					get() {
 						return window.location.hostname;
 					},
-					set(val) {
-						return val;
-					},
+					set() {},
 					configurable: true
 				});
-			} catch (e) {}
+			} catch {
+				/* intentional */
+			}
 		});
 
 		// Set random realistic user agent

--- a/meeple/headless.js
+++ b/meeple/headless.js
@@ -1,51 +1,47 @@
 // @ts-nocheck - This file heavily manipulates browser DOM elements with runtime types --- IGNORE ---
-import dotenv from "dotenv";
+import dotenv from 'dotenv';
 dotenv.config();
-import pLimit from "p-limit";
-import u from "ak-tools";
+import pLimit from 'p-limit';
+import u from 'ak-tools';
 
 /** @typedef {import('puppeteer').Page} Page */
 /** @typedef {import('puppeteer').Browser} Browser */
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
 
 // Import from new modular structure
-import { ensurePageSetup } from "./security.js";
+import { ensurePageSetup } from './security.js';
+import { selectPersona, generatePersonaActionSequence, getContextAwareAction } from './personas.js';
 import {
-  selectPersona,
-  generatePersonaActionSequence,
-  getContextAwareAction,
-} from "./personas.js";
+	wait,
+	exploratoryClick,
+	rageClick,
+	clickStuff,
+	intelligentScroll,
+	naturalMouseMovement,
+	hoverOverElements,
+	randomMouse,
+	randomScroll,
+	deadClick,
+	confusedBehavior
+} from './interactions.js';
+import { interactWithForms } from './forms.js';
+import { navigateBack, navigateForward } from './navigation.js';
+import { identifyHotZones } from './hotzones.js';
 import {
-  wait,
-  exploratoryClick,
-  rageClick,
-  clickStuff,
-  intelligentScroll,
-  naturalMouseMovement,
-  hoverOverElements,
-  randomMouse,
-  randomScroll,
-  deadClick,
-  confusedBehavior,
-} from "./interactions.js";
-import { interactWithForms } from "./forms.js";
-import { navigateBack, navigateForward } from "./navigation.js";
-import { identifyHotZones } from "./hotzones.js";
-import {
-  launchBrowser,
-  createPage,
-  navigateToUrl,
-  getPageInfo,
-  closeBrowser,
-  applyNetworkThrottling,
-  enableChaosMode,
-} from "./browser.js";
-import { executeSequence } from "./sequences.js";
-import { randomBetween, sleep } from "./utils.js";
+	launchBrowser,
+	createPage,
+	navigateToUrl,
+	getPageInfo,
+	closeBrowser,
+	applyNetworkThrottling,
+	enableChaosMode
+} from './browser.js';
+import { executeSequence } from './sequences.js';
+import { randomBetween, sleep } from './utils.js';
 
-const { NODE_ENV = "" } = process.env;
-let { MIXPANEL_TOKEN = "" } = process.env;
-if (!NODE_ENV) throw new Error("NODE_ENV is required");
+const { NODE_ENV = '' } = process.env;
+let { MIXPANEL_TOKEN = '' } = process.env;
+if (!NODE_ENV) throw new Error('NODE_ENV is required');
 
 /**
  * Main function to simulate user behavior.
@@ -54,195 +50,186 @@ if (!NODE_ENV) throw new Error("NODE_ENV is required");
  * @returns {Promise<import('../index.js').SimulationResult[]>} Array of simulation results
  */
 export default async function main(PARAMS = {}, logFunction = null) {
-  // Guard against missing logger for tests - fallback to console.log
-  const log = logFunction || ((message) => console.log(message));
-  let {
-    url = "https://mixpanel.github.io/fixpanel/",
-    users = 10,
-    concurrency = 10,
-    headless = true,
-    inject = true,
-    past = false,
-    token = "",
-    maxActions = null,
-    masking = false,
-    sequences = null,
-    // Friction behaviors
-    networkProfile = "fast",
-    chaosMode = false,
-    chaosFailRate = 0.15,
-    formMistakes = false,
-  } = PARAMS;
+	// Guard against missing logger for tests - fallback to console.log
+	const log = logFunction || (message => console.log(message));
+	let {
+		url = 'https://mixpanel.github.io/fixpanel/',
+		users = 10,
+		concurrency = 10,
+		headless = true,
+		inject = true,
+		past = false,
+		token = '',
+		maxActions = null,
+		masking = false,
+		sequences = null,
+		// Friction behaviors
+		networkProfile = 'fast',
+		chaosMode = false,
+		chaosFailRate = 0.15,
+		formMistakes = false
+	} = PARAMS;
 
-  if (url === "fixpanel") url = `https://mixpanel.github.io/fixpanel/`;
-  if (users > 25) users = 25;
-  if (concurrency > 10) concurrency = 10;
-  const limit = pLimit(concurrency);
-  if (token) MIXPANEL_TOKEN = token;
-  if (NODE_ENV === "production") headless = true; // Always headless in production
+	if (url === 'fixpanel') url = `https://mixpanel.github.io/fixpanel/`;
+	if (users > 25) users = 25;
+	if (concurrency > 10) concurrency = 10;
+	const limit = pLimit(concurrency);
+	if (token) MIXPANEL_TOKEN = token;
+	if (NODE_ENV === 'production') headless = true; // Always headless in production
 
-  // Prepare sequence distribution if sequences are provided
-  let sequenceNames = [];
-  if (sequences && typeof sequences === "object") {
-    sequenceNames = Object.keys(sequences);
-    log(
-      `🎯 <span style="color: #7856FF;">Deterministic sequences detected:</span> ${sequenceNames.length} sequence(s) available`,
-    );
-    sequenceNames.forEach((name) => {
-      const seq = sequences[name];
-      log(
-        `  ├─ "${name}": ${seq.description || "No description"} (temp: ${seq.temperature || 5}, ${seq.actions?.length || 0} actions)`,
-      );
-    });
-  }
+	// Prepare sequence distribution if sequences are provided
+	let sequenceNames = [];
+	if (sequences && typeof sequences === 'object') {
+		sequenceNames = Object.keys(sequences);
+		log(
+			`🎯 <span style="color: #7856FF;">Deterministic sequences detected:</span> ${sequenceNames.length} sequence(s) available`
+		);
+		sequenceNames.forEach(name => {
+			const seq = sequences[name];
+			log(
+				`  ├─ "${name}": ${seq.description || 'No description'} (temp: ${seq.temperature || 5}, ${seq.actions?.length || 0} actions)`
+			);
+		});
+	}
 
-  const userPromises = Array.from({ length: users }, (_, i) => {
-    return limit(() => {
-      // Generate unique username for this meeple
-      const usersHandle = u.makeName(3, "-");
+	const userPromises = Array.from({ length: users }, (_, i) => {
+		return limit(() => {
+			// Generate unique username for this meeple
+			const usersHandle = u.makeName(3, '-');
 
-      // Select sequence for this user if sequences are available
-      let selectedSequence = null;
-      let selectedSequenceName = null;
-      if (sequenceNames.length > 0) {
-        // Distribute sequences evenly among users, with cycling if more users than sequences
-        selectedSequenceName = sequenceNames[i % sequenceNames.length];
-        selectedSequence = sequences[selectedSequenceName];
-        log(
-          `🎯 <span style="color: #9B59B6;">${usersHandle} assigned sequence:</span> "${selectedSequenceName}"`,
-          usersHandle,
-        );
-      }
+			// Select sequence for this user if sequences are available
+			let selectedSequence = null;
+			let selectedSequenceName = null;
+			if (sequenceNames.length > 0) {
+				// Distribute sequences evenly among users, with cycling if more users than sequences
+				selectedSequenceName = sequenceNames[i % sequenceNames.length];
+				selectedSequence = sequences[selectedSequenceName];
+				log(
+					`🎯 <span style="color: #9B59B6;">${usersHandle} assigned sequence:</span> "${selectedSequenceName}"`,
+					usersHandle
+				);
+			}
 
-      log(
-        `🚀 <span style="color: #7856FF; font-weight: bold;">Spawning ${usersHandle}</span> (${i + 1}/${users}) on <span style="color: #80E1D9;">${url}</span>...`,
-        usersHandle,
-      );
+			log(
+				`🚀 <span style="color: #7856FF; font-weight: bold;">Spawning ${usersHandle}</span> (${i + 1}/${users}) on <span style="color: #80E1D9;">${url}</span>...`,
+				usersHandle
+			);
 
-      // Return the promise directly from simulateUser, handling success/error cases
-      return simulateUser(
-        url,
-        headless,
-        inject,
-        past,
-        maxActions,
-        usersHandle,
-        {
-          masking,
-          sequence: selectedSequence,
-          sequenceName: selectedSequenceName,
-          networkProfile,
-          chaosMode,
-          chaosFailRate,
-          formMistakes,
-        },
-        log,
-      )
-        .then((result) => {
-          if (result && !result.error && !result.timedOut) {
-            log(
-              `✅ <span style="color: #07B096;">${usersHandle} completed!</span> Session data captured.`,
-              usersHandle,
-            );
-            log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
-          } else if (result && result.timedOut) {
-            log(
-              `⏰ <span style="color: #F8BC3B;">${usersHandle} timed out</span> - but simulation continues`,
-              usersHandle,
-            );
-            log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
-          } else {
-            log(
-              `⚠️ <span style="color: #F8BC3B;">${usersHandle} completed with issues</span> - but simulation continues`,
-              usersHandle,
-            );
-            log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
-          }
+			// Return the promise directly from simulateUser, handling success/error cases
+			return simulateUser(
+				url,
+				headless,
+				inject,
+				past,
+				maxActions,
+				usersHandle,
+				{
+					masking,
+					sequence: selectedSequence,
+					sequenceName: selectedSequenceName,
+					networkProfile,
+					chaosMode,
+					chaosFailRate,
+					formMistakes
+				},
+				log
+			)
+				.then(result => {
+					if (result && !result.error && !result.timedOut) {
+						log(
+							`✅ <span style="color: #07B096;">${usersHandle} completed!</span> Session data captured.`,
+							usersHandle
+						);
+						log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
+					} else if (result && result.timedOut) {
+						log(
+							`⏰ <span style="color: #F8BC3B;">${usersHandle} timed out</span> - but simulation continues`,
+							usersHandle
+						);
+						log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
+					} else {
+						log(
+							`⚠️ <span style="color: #F8BC3B;">${usersHandle} completed with issues</span> - but simulation continues`,
+							usersHandle
+						);
+						log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
+					}
 
-          return result || { error: "Unknown error", user: i + 1 };
-        })
-        .catch((e) => {
-          const errorMsg = e.message || "Unknown error";
-          log(
-            `❌ <span style="color: #CC332B;">${usersHandle} failed:</span> ${errorMsg} - <span style="color: #888;">continuing with other users</span>`,
-            usersHandle,
-          );
-          log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
-          return { error: errorMsg, user: i + 1, crashed: true };
-        });
-    });
-  });
+					return result || { error: 'Unknown error', user: i + 1 };
+				})
+				.catch(e => {
+					const errorMsg = e.message || 'Unknown error';
+					log(
+						`❌ <span style="color: #CC332B;">${usersHandle} failed:</span> ${errorMsg} - <span style="color: #888;">continuing with other users</span>`,
+						usersHandle
+					);
+					log(`🔚 ${usersHandle} simulation complete.`, usersHandle); // Final completion message for tab closure
+					return { error: errorMsg, user: i + 1, crashed: true };
+				});
+		});
+	});
 
-  // Use Promise.allSettled instead of Promise.all to prevent one failure from stopping everything
-  const results = await Promise.allSettled(userPromises);
+	// Use Promise.allSettled instead of Promise.all to prevent one failure from stopping everything
+	const results = await Promise.allSettled(userPromises);
 
-  // Process results and provide summary
-  // @ts-ignore
-  const successful = results.filter(
-    (r) =>
-      r.status === "fulfilled" && r.value && !r.value.error && !r.value.crashed,
-  ).length;
-  // @ts-ignore
-  const timedOut = results.filter(
-    (r) => r.status === "fulfilled" && r.value && r.value.timedOut,
-  ).length;
-  // @ts-ignore
-  const crashed = results.filter(
-    (r) => r.status === "fulfilled" && r.value && r.value.crashed,
-  ).length;
-  const failed = results.filter((r) => r.status === "rejected").length;
+	// Process results and provide summary
+	// @ts-ignore
+	const successful = results.filter(
+		r => r.status === 'fulfilled' && r.value && !r.value.error && !r.value.crashed
+	).length;
+	// @ts-ignore
+	const timedOut = results.filter(r => r.status === 'fulfilled' && r.value && r.value.timedOut).length;
+	// @ts-ignore
+	const crashed = results.filter(r => r.status === 'fulfilled' && r.value && r.value.crashed).length;
+	const failed = results.filter(r => r.status === 'rejected').length;
 
-  // Enhanced simulation summary for general tab
-  log(
-    `📊 <span style="color: #7856FF;">Simulation Summary:</span> ${successful}/${users} successful, ${timedOut} timed out, ${crashed} crashed, ${failed} rejected`,
-  );
+	// Enhanced simulation summary for general tab
+	log(
+		`📊 <span style="color: #7856FF;">Simulation Summary:</span> ${successful}/${users} successful, ${timedOut} timed out, ${crashed} crashed, ${failed} rejected`
+	);
 
-  // Calculate total actions performed
-  let totalActions = 0;
-  let totalSuccessfulActions = 0;
+	// Calculate total actions performed
+	let totalActions = 0;
+	let totalSuccessfulActions = 0;
 
-  // Return the actual results, filtering out any undefined values
-  const finalResults = results
-    .map((r) => {
-      if (r.status === "fulfilled") {
-        const result = r.value;
-        if (result && result.actions) {
-          totalActions += result.actions.length;
-          totalSuccessfulActions += result.actions.filter(
-            (action) => action.success !== false,
-          ).length;
-        }
-        return result;
-      } else {
-        log(
-          `⚠️ <span style="color: #CC332B;">Promise rejected:</span> ${r.reason?.message || "Unknown error"}`,
-        );
-        return {
-          error: r.reason?.message || "Promise rejected",
-          crashed: true,
-        };
-      }
-    })
-    .filter(Boolean);
+	// Return the actual results, filtering out any undefined values
+	const finalResults = results
+		.map(r => {
+			if (r.status === 'fulfilled') {
+				const result = r.value;
+				if (result && result.actions) {
+					totalActions += result.actions.length;
+					totalSuccessfulActions += result.actions.filter(action => action.success !== false).length;
+				}
+				return result;
+			} else {
+				log(`⚠️ <span style="color: #CC332B;">Promise rejected:</span> ${r.reason?.message || 'Unknown error'}`);
+				return {
+					error: r.reason?.message || 'Promise rejected',
+					crashed: true
+				};
+			}
+		})
+		.filter(Boolean);
 
-  // Send detailed summary to general tab (null meepleId)
-  log(``, null); // Empty line
-  log(`🎯 <span style="color: #07B096;">Mission Accomplished!</span>`, null);
-  log(`📈 Total Actions Performed: ${totalActions}`, null);
-  log(`✅ Successful Actions: ${totalSuccessfulActions}`, null);
-  log(
-    `📊 Action Success Rate: ${totalActions > 0 ? ((totalSuccessfulActions / totalActions) * 100).toFixed(1) : 0}%`,
-    null,
-  );
-  log(`🤖 Meeple Performance:`, null);
-  log(`  ├─ ✅ Completed successfully: ${successful}`, null);
-  if (timedOut > 0) log(`  ├─ ⏰ Timed out: ${timedOut}`, null);
-  if (crashed > 0) log(`  ├─ 💥 Crashed: ${crashed}`, null);
-  if (failed > 0) log(`  └─ ❌ Failed to start: ${failed}`, null);
-  log(``, null); // Empty line
-  log(`🎉 All meeples have completed their digital adventures!`, null);
+	// Send detailed summary to general tab (null meepleId)
+	log(``, null); // Empty line
+	log(`🎯 <span style="color: #07B096;">Mission Accomplished!</span>`, null);
+	log(`📈 Total Actions Performed: ${totalActions}`, null);
+	log(`✅ Successful Actions: ${totalSuccessfulActions}`, null);
+	log(
+		`📊 Action Success Rate: ${totalActions > 0 ? ((totalSuccessfulActions / totalActions) * 100).toFixed(1) : 0}%`,
+		null
+	);
+	log(`🤖 Meeple Performance:`, null);
+	log(`  ├─ ✅ Completed successfully: ${successful}`, null);
+	if (timedOut > 0) log(`  ├─ ⏰ Timed out: ${timedOut}`, null);
+	if (crashed > 0) log(`  ├─ 💥 Crashed: ${crashed}`, null);
+	if (failed > 0) log(`  └─ ❌ Failed to start: ${failed}`, null);
+	log(``, null); // Empty line
+	log(`🎉 All meeples have completed their digital adventures!`, null);
 
-  return finalResults;
+	return finalResults;
 }
 
 /**
@@ -258,212 +245,192 @@ export default async function main(PARAMS = {}, logFunction = null) {
  * @returns {Promise<import('../index.js').SimulationResult>} Simulation result
  */
 export async function simulateUser(
-  url,
-  headless = true,
-  inject = true,
-  _past = false,
-  maxActions = null,
-  usersHandle = null,
-  opts = {},
-  logFunction = console.log,
+	url,
+	headless = true,
+	inject = true,
+	_past = false,
+	maxActions = null,
+	usersHandle = null,
+	opts = {},
+	logFunction = console.log
 ) {
-  // Create user-specific logger that automatically includes the usersHandle
-  const log = usersHandle
-    ? (message) => logFunction(message, usersHandle)
-    : logFunction;
+	// Create user-specific logger that automatically includes the usersHandle
+	const log = usersHandle ? message => logFunction(message, usersHandle) : logFunction;
 
-  // Generate a unique location for this meeple
-  function generateLocation() {
-    const cities = [
-      [40.7128, -74.006], // New York
-      [51.5074, -0.1278], // London
-      [35.6762, 139.6503], // Tokyo
-      [48.8566, 2.3522], // Paris
-      [34.0522, -118.2437], // Los Angeles
-      [-33.8688, 151.2093], // Sydney
-      [55.7558, 37.6173], // Moscow
-      [39.9042, 116.4074], // Beijing
-      [19.076, 72.8777], // Mumbai
-      [-23.5505, -46.6333], // São Paulo
-    ];
+	// Generate a unique location for this meeple
+	function generateLocation() {
+		const cities = [
+			[40.7128, -74.006], // New York
+			[51.5074, -0.1278], // London
+			[35.6762, 139.6503], // Tokyo
+			[48.8566, 2.3522], // Paris
+			[34.0522, -118.2437], // Los Angeles
+			[-33.8688, 151.2093], // Sydney
+			[55.7558, 37.6173], // Moscow
+			[39.9042, 116.4074], // Beijing
+			[19.076, 72.8777], // Mumbai
+			[-23.5505, -46.6333] // São Paulo
+		];
 
-    const city = cities[Math.floor(Math.random() * cities.length)];
-    const radius = 2; // degrees (~200km)
+		const city = cities[Math.floor(Math.random() * cities.length)];
+		const radius = 2; // degrees (~200km)
 
-    const lat = city[0] + (Math.random() - 0.5) * radius;
-    const lon = city[1] + (Math.random() - 0.5) * radius;
+		const lat = city[0] + (Math.random() - 0.5) * radius;
+		const lon = city[1] + (Math.random() - 0.5) * radius;
 
-    return {
-      lat: parseFloat(lat.toFixed(6)),
-      lon: parseFloat(lon.toFixed(6)),
-    };
-  }
+		return {
+			lat: parseFloat(lat.toFixed(6)),
+			lon: parseFloat(lon.toFixed(6))
+		};
+	}
 
-  const meepleLocation = generateLocation();
-  log(
-    `🌍 <span style="color: #80E1D9;">${usersHandle}</span> location: ${meepleLocation.lat}, ${meepleLocation.lon}`,
-  );
+	const meepleLocation = generateLocation();
+	log(`🌍 <span style="color: #80E1D9;">${usersHandle}</span> location: ${meepleLocation.lat}, ${meepleLocation.lon}`);
 
-  // Add location to opts for this meeple
-  const meepleOpts = { ...opts, location: meepleLocation };
+	// Add location to opts for this meeple
+	const meepleOpts = { ...opts, location: meepleLocation };
 
-  const totalTimeout = 10 * 60 * 1000; // max 10 min / user
-  const timeoutPromise = new Promise((resolve) =>
-    setTimeout(() => {
-      resolve({ timedOut: true, error: "Session timeout" });
-    }, totalTimeout),
-  );
+	const totalTimeout = 10 * 60 * 1000; // max 10 min / user
+	const timeoutPromise = new Promise(resolve =>
+		setTimeout(() => {
+			resolve({ timedOut: true, error: 'Session timeout' });
+		}, totalTimeout)
+	);
 
-  let browser;
+	let browser;
 
-  // Define the user session simulation promise
-  const simulationPromise = (async () => {
-    try {
-      browser = await launchBrowser(headless, log);
-      const page = await createPage(browser, log);
-      page.MIXPANEL_TOKEN = MIXPANEL_TOKEN;
+	// Define the user session simulation promise
+	const simulationPromise = (async () => {
+		try {
+			browser = await launchBrowser(headless, log);
+			const page = await createPage(browser, log);
+			page.MIXPANEL_TOKEN = MIXPANEL_TOKEN;
 
-      // Apply friction behaviors if configured
-      if (meepleOpts.networkProfile && meepleOpts.networkProfile !== "fast") {
-        await applyNetworkThrottling(page, meepleOpts.networkProfile, log);
-      }
-      if (meepleOpts.chaosMode) {
-        await enableChaosMode(page, meepleOpts.chaosFailRate || 0.15, log);
-      }
+			// Apply friction behaviors if configured
+			if (meepleOpts.networkProfile && meepleOpts.networkProfile !== 'fast') {
+				await applyNetworkThrottling(page, meepleOpts.networkProfile, log);
+			}
+			if (meepleOpts.chaosMode) {
+				await enableChaosMode(page, meepleOpts.chaosFailRate || 0.15, log);
+			}
 
-      // Validate and navigate to URL
-      let navigationUrl;
-      try {
-        const urlObj = new URL(url);
+			// Validate and navigate to URL
+			let navigationUrl;
+			try {
+				const urlObj = new URL(url);
 
-        // Add meeple tracking parameters for Mixpanel analytics
-        urlObj.searchParams.set("IS_MEEPLE", "true");
-        urlObj.searchParams.set("MEEPLE_ID", usersHandle);
-        if (opts.sequenceName) {
-          urlObj.searchParams.set("SEQUENCE", opts.sequenceName);
-        }
+				// Add meeple tracking parameters for Mixpanel analytics
+				urlObj.searchParams.set('IS_MEEPLE', 'true');
+				urlObj.searchParams.set('MEEPLE_ID', usersHandle);
+				if (opts.sequenceName) {
+					urlObj.searchParams.set('SEQUENCE', opts.sequenceName);
+				}
 
-        navigationUrl = urlObj.toString();
-      } catch (urlError) {
-        throw new Error(`Invalid URL provided: ${url} - ${urlError.message}`);
-      }
+				navigationUrl = urlObj.toString();
+			} catch (urlError) {
+				throw new Error(`Invalid URL provided: ${url} - ${urlError.message}`);
+			}
 
-      await navigateToUrl(page, navigationUrl, log, meepleOpts);
-      // Set up page environment
-      await ensurePageSetup(page, usersHandle, inject, meepleOpts, log);
-      await sleep(randomBetween(50, 250)); // Random sleep to simulate human behavior (was 100-500ms)
+			await navigateToUrl(page, navigationUrl, log, meepleOpts);
+			// Set up page environment
+			await ensurePageSetup(page, usersHandle, inject, meepleOpts, log);
+			await sleep(randomBetween(50, 250)); // Random sleep to simulate human behavior (was 100-500ms)
 
-      const pageInfo = await getPageInfo(page, log);
-      log(`📄 Page loaded: "${pageInfo.title}"`);
+			const pageInfo = await getPageInfo(page, log);
+			log(`📄 Page loaded: "${pageInfo.title}"`);
 
-      // Identify hot zones for intelligent targeting
-      const hotZones = await identifyHotZones(page);
-      log(
-        `🎯 <span style="color: #7856FF;">Hot zones identified:</span> ${hotZones.length} priority elements`,
-      );
+			// Identify hot zones for intelligent targeting
+			const hotZones = await identifyHotZones(page);
+			log(`🎯 <span style="color: #7856FF;">Hot zones identified:</span> ${hotZones.length} priority elements`);
 
-      // Select persona and generate action sequence or use provided sequence
-      const persona = selectPersona(log);
-      let actionResults;
-      const startTime = Date.now();
+			// Select persona and generate action sequence or use provided sequence
+			const persona = selectPersona(log);
+			let actionResults;
+			const startTime = Date.now();
 
-      // Check if a deterministic sequence is provided
-      let circuitBreakerTriggered = false;
-      let failedActions = [];
+			// Check if a deterministic sequence is provided
+			let circuitBreakerTriggered = false;
+			let failedActions = [];
 
-      if (meepleOpts.sequence && meepleOpts.sequenceName) {
-        log(
-          `🎯 <span style="color: #9B59B6;">Executing deterministic sequence:</span> "${meepleOpts.sequenceName}"`,
-        );
-        log(
-          `🎭 <span style="color: #7856FF;">Persona:</span> ${persona} (for fallback actions)`,
-        );
+			if (meepleOpts.sequence && meepleOpts.sequenceName) {
+				log(`🎯 <span style="color: #9B59B6;">Executing deterministic sequence:</span> "${meepleOpts.sequenceName}"`);
+				log(`🎭 <span style="color: #7856FF;">Persona:</span> ${persona} (for fallback actions)`);
 
-        // Execute the deterministic sequence
-        const sequenceResult = await executeSequence(
-          page,
-          meepleOpts.sequence,
-          hotZones,
-          persona,
-          usersHandle,
-          meepleOpts,
-          log,
-        );
+				// Execute the deterministic sequence
+				const sequenceResult = await executeSequence(
+					page,
+					meepleOpts.sequence,
+					hotZones,
+					persona,
+					usersHandle,
+					meepleOpts,
+					log
+				);
 
-        // Handle new return format from executeSequence
-        actionResults = sequenceResult.actionResults || sequenceResult;
-        circuitBreakerTriggered =
-          sequenceResult.circuitBreakerTriggered || false;
-        failedActions = sequenceResult.failedActions || [];
-      } else {
-        // Fall back to regular persona-based behavior
-        const actionSequence = generatePersonaActionSequence(
-          persona,
-          maxActions,
-        );
-        log(
-          `🎭 <span style="color: #7856FF;">Persona:</span> ${persona}, ${actionSequence.length} actions planned`,
-        );
+				// Handle new return format from executeSequence
+				actionResults = sequenceResult.actionResults || sequenceResult;
+				circuitBreakerTriggered = sequenceResult.circuitBreakerTriggered || false;
+				failedActions = sequenceResult.failedActions || [];
+			} else {
+				// Fall back to regular persona-based behavior
+				const actionSequence = generatePersonaActionSequence(persona, maxActions);
+				log(`🎭 <span style="color: #7856FF;">Persona:</span> ${persona}, ${actionSequence.length} actions planned`);
 
-        actionResults = await simulateUserSession(
-          page,
-          actionSequence,
-          hotZones,
-          persona,
-          usersHandle,
-          meepleOpts,
-          log,
-        );
-      }
+				actionResults = await simulateUserSession(
+					page,
+					actionSequence,
+					hotZones,
+					persona,
+					usersHandle,
+					meepleOpts,
+					log
+				);
+			}
 
-      await closeBrowser(browser);
+			await closeBrowser(browser);
 
-      const durationSec = Math.round((Date.now() - startTime) / 1000);
-      log(
-        `⏱️ <span style="color: #7856FF;">Session completed in ${durationSec}s</span>`,
-      );
+			const durationSec = Math.round((Date.now() - startTime) / 1000);
+			log(`⏱️ <span style="color: #7856FF;">Session completed in ${durationSec}s</span>`);
 
-      const result = {
-        actions: actionResults,
-        duration: durationSec,
-        persona,
-        sequence: meepleOpts.sequenceName || null,
-        success: true,
-      };
+			const result = {
+				actions: actionResults,
+				duration: durationSec,
+				persona,
+				sequence: meepleOpts.sequenceName || null,
+				success: true
+			};
 
-      // Add circuit breaker metadata if a sequence was executed
-      if (meepleOpts.sequence && meepleOpts.sequenceName) {
-        result.circuit_breaker_triggered = circuitBreakerTriggered;
-        if (failedActions.length > 0) {
-          result.failed_actions = failedActions;
-        }
-      }
+			// Add circuit breaker metadata if a sequence was executed
+			if (meepleOpts.sequence && meepleOpts.sequenceName) {
+				result.circuit_breaker_triggered = circuitBreakerTriggered;
+				if (failedActions.length > 0) {
+					result.failed_actions = failedActions;
+				}
+			}
 
-      return result;
-    } catch (error) {
-      if (browser) {
-        await closeBrowser(browser);
-      }
-      log(
-        `🚨 <span style="color: #CC332B;">Session error:</span> ${error.message}`,
-      );
-      return { error: error.message, timedOut: false };
-    }
-  })();
+			return result;
+		} catch (error) {
+			if (browser) {
+				await closeBrowser(browser);
+			}
+			log(`🚨 <span style="color: #CC332B;">Session error:</span> ${error.message}`);
+			return { error: error.message, timedOut: false };
+		}
+	})();
 
-  // Use Promise.race to handle timeout
-  try {
-    return await Promise.race([simulationPromise, timeoutPromise]);
-  } catch (error) {
-    if (browser) {
-      try {
-        await closeBrowser(browser);
-      } catch (closeError) {
-        log(`⚠️ Browser close error: ${closeError.message}`);
-      }
-    }
-    return { error: error.message || "Unknown error", timedOut: false };
-  }
+	// Use Promise.race to handle timeout
+	try {
+		return await Promise.race([simulationPromise, timeoutPromise]);
+	} catch (error) {
+		if (browser) {
+			try {
+				await closeBrowser(browser);
+			} catch (closeError) {
+				log(`⚠️ Browser close error: ${closeError.message}`);
+			}
+		}
+		return { error: error.message || 'Unknown error', timedOut: false };
+	}
 }
 
 /**
@@ -477,179 +444,157 @@ export async function simulateUser(
  * @param {Function} log - Logging function
  * @returns {Promise<Array>} Array of completed actions
  */
-async function simulateUserSession(
-  page,
-  actionSequence,
-  hotZones,
-  persona,
-  usersHandle,
-  opts,
-  log,
-) {
-  const actionResults = [];
-  const actionHistory = [];
-  const hoverHistory = []; // Track hover interactions for return visit behavior
-  let consecutiveFailures = 0;
-  const maxConsecutiveFailures = 5;
-  let currentUrl = page.url(); // Track URL changes for hot zone re-detection
+async function simulateUserSession(page, actionSequence, hotZones, persona, usersHandle, opts, log) {
+	const actionResults = [];
+	const actionHistory = [];
+	const hoverHistory = []; // Track hover interactions for return visit behavior
+	let consecutiveFailures = 0;
+	const maxConsecutiveFailures = 5;
+	let currentUrl = page.url(); // Track URL changes for hot zone re-detection
 
-  const actionEmojis = {
-    click: "🖱️",
-    exploratoryClick: "🎯",
-    rageClick: "😡",
-    scroll: "📜",
-    mouse: "🖱️",
-    randomMouse: "🎲",
-    randomScroll: "🎯",
-    hover: "👁️",
-    wait: "⏸️",
-    form: "📝",
-    back: "⬅️",
-    forward: "➡️",
-    deadClick: "💀",
-    confusedBehavior: "🤔",
-  };
+	const actionEmojis = {
+		click: '🖱️',
+		exploratoryClick: '🎯',
+		rageClick: '😡',
+		scroll: '📜',
+		mouse: '🖱️',
+		randomMouse: '🎲',
+		randomScroll: '🎯',
+		hover: '👁️',
+		wait: '⏸️',
+		form: '📝',
+		back: '⬅️',
+		forward: '➡️',
+		deadClick: '💀',
+		confusedBehavior: '🤔'
+	};
 
-  for (const [index, originalAction] of actionSequence.entries()) {
-    // Chaos mode: randomly inject friction behaviors (10% dead clicks, 5% confused behavior)
-    let chaosAction = originalAction;
-    if (opts.chaosMode) {
-      const roll = Math.random();
-      if (roll < 0.1) {
-        chaosAction = "deadClick";
-      } else if (roll < 0.15) {
-        chaosAction = "confusedBehavior";
-      }
-    }
+	for (const [index, originalAction] of actionSequence.entries()) {
+		// Chaos mode: randomly inject friction behaviors (10% dead clicks, 5% confused behavior)
+		let chaosAction = originalAction;
+		if (opts.chaosMode) {
+			const roll = Math.random();
+			if (roll < 0.1) {
+				chaosAction = 'deadClick';
+			} else if (roll < 0.15) {
+				chaosAction = 'confusedBehavior';
+			}
+		}
 
-    // Apply context-aware action selection
-    const action = getContextAwareAction(actionHistory, chaosAction, log);
+		// Apply context-aware action selection
+		const action = getContextAwareAction(actionHistory, chaosAction, log);
 
-    const emoji = actionEmojis[action] || "🎯";
-    const contextNote =
-      action !== originalAction
-        ? ` <span style="color: #888;">(adapted from ${originalAction})</span>`
-        : "";
-    log(
-      `  ├─ ${emoji} <span style="color: #FF7557;">Action ${index + 1}/${actionSequence.length}</span>: ${action}${contextNote}`,
-    );
+		const emoji = actionEmojis[action] || '🎯';
+		const contextNote =
+			action !== originalAction ? ` <span style="color: #888;">(adapted from ${originalAction})</span>` : '';
+		log(
+			`  ├─ ${emoji} <span style="color: #FF7557;">Action ${index + 1}/${actionSequence.length}</span>: ${action}${contextNote}`
+		);
 
-    let funcToPerform;
-    // Check for URL changes and re-identify hot zones if needed
-    const newUrl = page.url();
-    if (newUrl !== currentUrl) {
-      log(`🔄 URL changed, re-identifying hot zones...`);
-      hotZones.length = 0; // Clear existing hot zones
-      const newHotZones = await identifyHotZones(page);
-      hotZones.push(...newHotZones);
-      currentUrl = newUrl;
-      log(`🎯 Updated: ${hotZones.length} hot zones identified`);
-    }
+		let funcToPerform;
+		// Check for URL changes and re-identify hot zones if needed
+		const newUrl = page.url();
+		if (newUrl !== currentUrl) {
+			log(`🔄 URL changed, re-identifying hot zones...`);
+			hotZones.length = 0; // Clear existing hot zones
+			const newHotZones = await identifyHotZones(page);
+			hotZones.push(...newHotZones);
+			currentUrl = newUrl;
+			log(`🎯 Updated: ${hotZones.length} hot zones identified`);
+		}
 
-    switch (action) {
-      case "click":
-        funcToPerform = () => clickStuff(page, hotZones, log);
-        break;
-      case "exploratoryClick":
-        funcToPerform = () => exploratoryClick(page, log);
-        break;
-      case "rageClick":
-        funcToPerform = () => rageClick(page, log);
-        break;
-      case "scroll":
-        funcToPerform = () => intelligentScroll(page, hotZones, log);
-        break;
-      case "mouse":
-        funcToPerform = () => naturalMouseMovement(page, hotZones, log);
-        break;
-      case "moveMouse":
-        funcToPerform = () => naturalMouseMovement(page, hotZones, log);
-        break;
-      case "randomMouse":
-        funcToPerform = () => randomMouse(page, log);
-        break;
-      case "randomScroll":
-        funcToPerform = () => randomScroll(page, log);
-        break;
-      case "hover":
-        funcToPerform = () =>
-          hoverOverElements(page, hotZones, persona, hoverHistory, log);
-        break;
-      case "form":
-        funcToPerform = () =>
-          interactWithForms(page, log, { formMistakes: opts.formMistakes });
-        break;
-      case "deadClick":
-        funcToPerform = () => deadClick(page, hotZones, log);
-        break;
-      case "confusedBehavior":
-        funcToPerform = () => confusedBehavior(page, log);
-        break;
-      case "back":
-        funcToPerform = () => navigateBack(page, log);
-        break;
-      case "forward":
-        funcToPerform = () => navigateForward(page, log);
-        break;
-      case "wait":
-        funcToPerform = () => wait();
-        break;
-      default:
-        funcToPerform = () => wait();
-        break;
-    }
+		switch (action) {
+			case 'click':
+				funcToPerform = () => clickStuff(page, hotZones, log);
+				break;
+			case 'exploratoryClick':
+				funcToPerform = () => exploratoryClick(page, log);
+				break;
+			case 'rageClick':
+				funcToPerform = () => rageClick(page, log);
+				break;
+			case 'scroll':
+				funcToPerform = () => intelligentScroll(page, hotZones, log);
+				break;
+			case 'mouse':
+				funcToPerform = () => naturalMouseMovement(page, hotZones, log);
+				break;
+			case 'moveMouse':
+				funcToPerform = () => naturalMouseMovement(page, hotZones, log);
+				break;
+			case 'randomMouse':
+				funcToPerform = () => randomMouse(page, log);
+				break;
+			case 'randomScroll':
+				funcToPerform = () => randomScroll(page, log);
+				break;
+			case 'hover':
+				funcToPerform = () => hoverOverElements(page, hotZones, persona, hoverHistory, log);
+				break;
+			case 'form':
+				funcToPerform = () => interactWithForms(page, log, { formMistakes: opts.formMistakes });
+				break;
+			case 'deadClick':
+				funcToPerform = () => deadClick(page, hotZones, log);
+				break;
+			case 'confusedBehavior':
+				funcToPerform = () => confusedBehavior(page, log);
+				break;
+			case 'back':
+				funcToPerform = () => navigateBack(page, log);
+				break;
+			case 'forward':
+				funcToPerform = () => navigateForward(page, log);
+				break;
+			case 'wait':
+				funcToPerform = () => wait();
+				break;
+			default:
+				funcToPerform = () => wait();
+				break;
+		}
 
-    try {
-      // Ensure page setup before each action
-      await ensurePageSetup(
-        page,
-        usersHandle,
-        opts.inject !== false,
-        opts,
-        log,
-      );
+		try {
+			// Ensure page setup before each action
+			await ensurePageSetup(page, usersHandle, opts.inject !== false, opts, log);
 
-      // Execute action with timeout
-      const actionTimeout = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error("Action timeout")), 30000),
-      );
+			// Execute action with timeout
+			const actionTimeout = new Promise((_, reject) => setTimeout(() => reject(new Error('Action timeout')), 30000));
 
-      await Promise.race([funcToPerform(), actionTimeout]);
+			await Promise.race([funcToPerform(), actionTimeout]);
 
-      actionResults.push(action);
-      consecutiveFailures = 0; // Reset failure count on success
-      actionHistory.push({
-        action,
-        success: true,
-        timestamp: Date.now(),
-      });
-    } catch (actionError) {
-      consecutiveFailures++;
-      log(
-        `    ├─ ⚠️ <span style="color: #F8BC3B;">Action failed:</span> ${actionError.message}`,
-      );
+			actionResults.push(action);
+			consecutiveFailures = 0; // Reset failure count on success
+			actionHistory.push({
+				action,
+				success: true,
+				timestamp: Date.now()
+			});
+		} catch (actionError) {
+			consecutiveFailures++;
+			log(`    ├─ ⚠️ <span style="color: #F8BC3B;">Action failed:</span> ${actionError.message}`);
 
-      actionHistory.push({
-        action,
-        success: false,
-        error: actionError.message,
-        timestamp: Date.now(),
-      });
+			actionHistory.push({
+				action,
+				success: false,
+				error: actionError.message,
+				timestamp: Date.now()
+			});
 
-      // Circuit breaker: stop if too many consecutive failures
-      if (consecutiveFailures >= maxConsecutiveFailures) {
-        log(
-          `    └─ 🚨 <span style="color: #CC332B;">Too many consecutive failures (${consecutiveFailures}), terminating session</span>`,
-        );
-        break;
-      }
-    }
+			// Circuit breaker: stop if too many consecutive failures
+			if (consecutiveFailures >= maxConsecutiveFailures) {
+				log(
+					`    └─ 🚨 <span style="color: #CC332B;">Too many consecutive failures (${consecutiveFailures}), terminating session</span>`
+				);
+				break;
+			}
+		}
 
-    // Random sleep between actions
-    await sleep(randomBetween(500, 2000));
-  }
+		// Random sleep between actions
+		await sleep(randomBetween(500, 2000));
+	}
 
-  return actionResults;
+	return actionResults;
 }
 
 // performScroll function removed - unused (intelligentScroll from interactions.js is used instead)

--- a/meeple/sequences.js
+++ b/meeple/sequences.js
@@ -2,20 +2,9 @@
 /** @typedef {import('puppeteer').Page} Page */
 /** @typedef {import('puppeteer').ElementHandle} ElementHandle */
 
-import {
-  wait,
-  naturalMouseMovement,
-  intelligentScroll,
-  exploratoryClick,
-} from "./interactions.js";
-import {
-  interactWithForms,
-  fillRadioGroup,
-  toggleCheckbox,
-  fillSelectDropdown,
-  fillTextInput,
-} from "./forms.js";
-import { randomBetween, sleep } from "./utils.js";
+import { wait, naturalMouseMovement, intelligentScroll, exploratoryClick } from './interactions.js';
+import { interactWithForms, fillRadioGroup, toggleCheckbox, fillSelectDropdown, fillTextInput } from './forms.js';
+import { randomBetween, sleep } from './utils.js';
 
 /**
  * Execute a deterministic sequence of actions with configurable temperature and chaos
@@ -28,174 +17,134 @@ import { randomBetween, sleep } from "./utils.js";
  * @param {import('../index.js').LogFunction} log - Logging function
  * @returns {Promise<import('../index.js').SequenceActionResult[]>} Array of completed actions
  */
-export async function executeSequence(
-  page,
-  sequenceSpec,
-  hotZones,
-  persona,
-  usersHandle,
-  opts,
-  log,
-) {
-  const {
-    description,
-    temperature = 5,
-    "chaos-range": chaosRange = [1, 1],
-    actions = [],
-    circuitBreaker = {},
-    debug = false,
-  } = sequenceSpec;
+export async function executeSequence(page, sequenceSpec, hotZones, persona, usersHandle, opts, log) {
+	const {
+		description,
+		temperature = 5,
+		'chaos-range': chaosRange = [1, 1],
+		actions = [],
+		circuitBreaker = {},
+		debug = false
+	} = sequenceSpec;
 
-  // Circuit breaker configuration with defaults
-  const {
-    maxFailures = 3,
-    resetOnSuccess = true,
-    mode = "terminate",
-  } = circuitBreaker;
+	// Circuit breaker configuration with defaults
+	const { maxFailures = 3, resetOnSuccess = true, mode = 'terminate' } = circuitBreaker;
 
-  log(`🎯 <span style="color: #7856FF;">Sequence:</span> ${description}`);
-  log(
-    `🌡️ <span style="color: #F39C12;">Temperature:</span> ${temperature}/10, Chaos: [${chaosRange[0]}-${chaosRange[1]}]`,
-  );
+	log(`🎯 <span style="color: #7856FF;">Sequence:</span> ${description}`);
+	log(
+		`🌡️ <span style="color: #F39C12;">Temperature:</span> ${temperature}/10, Chaos: [${chaosRange[0]}-${chaosRange[1]}]`
+	);
 
-  if (debug) {
-    log(
-      `🐛 <span style="color: #E67E22;">Debug mode enabled:</span> Verbose logging active`,
-    );
-    log(
-      `🛡️ <span style="color: #E67E22;">Circuit breaker:</span> maxFailures=${maxFailures}, mode=${mode}, resetOnSuccess=${resetOnSuccess}`,
-    );
-  }
+	if (debug) {
+		log(`🐛 <span style="color: #E67E22;">Debug mode enabled:</span> Verbose logging active`);
+		log(
+			`🛡️ <span style="color: #E67E22;">Circuit breaker:</span> maxFailures=${maxFailures}, mode=${mode}, resetOnSuccess=${resetOnSuccess}`
+		);
+	}
 
-  // Calculate effective temperature with chaos multiplier
-  const chaosMultiplier = randomBetween(chaosRange[0], chaosRange[1]) / 10;
-  const effectiveTemperature = Math.max(
-    0,
-    Math.min(10, temperature * chaosMultiplier),
-  );
+	// Calculate effective temperature with chaos multiplier
+	const chaosMultiplier = randomBetween(chaosRange[0], chaosRange[1]) / 10;
+	const effectiveTemperature = Math.max(0, Math.min(10, temperature * chaosMultiplier));
 
-  log(
-    `🎲 <span style="color: #9B59B6;">Effective temperature:</span> ${effectiveTemperature.toFixed(2)}/10`,
-  );
+	log(`🎲 <span style="color: #9B59B6;">Effective temperature:</span> ${effectiveTemperature.toFixed(2)}/10`);
 
-  const actionResults = [];
-  let consecutiveFailures = 0;
-  const maxConsecutiveFailures = maxFailures;
-  let circuitBreakerTriggered = false;
+	const actionResults = [];
+	let consecutiveFailures = 0;
+	const maxConsecutiveFailures = maxFailures;
+	let circuitBreakerTriggered = false;
 
-  for (const [index, action] of actions.entries()) {
-    try {
-      // Check if we should follow the sequence or go random based on temperature
-      const followSequence = Math.random() * 10 < effectiveTemperature;
+	for (const [index, action] of actions.entries()) {
+		try {
+			// Check if we should follow the sequence or go random based on temperature
+			const followSequence = Math.random() * 10 < effectiveTemperature;
 
-      if (followSequence) {
-        log(
-          `📋 <span style="color: #3498DB;">Action ${index + 1}/${actions.length}:</span> ${action.action} ${action.selector || ""}`,
-        );
+			if (followSequence) {
+				log(
+					`📋 <span style="color: #3498DB;">Action ${index + 1}/${actions.length}:</span> ${action.action} ${action.selector || ''}`
+				);
 
-        const result = await executeSequenceAction(
-          page,
-          action,
-          hotZones,
-          log,
-          debug,
-        );
-        actionResults.push(result);
+				const result = await executeSequenceAction(page, action, hotZones, log, debug);
+				actionResults.push(result);
 
-        // Handle success/failure based on circuit breaker config
-        if (result.success || result.skipped) {
-          if (resetOnSuccess) {
-            if (consecutiveFailures > 0 && debug) {
-              log(
-                `✅ <span style="color: #27AE60;">Success - resetting failure counter from ${consecutiveFailures} to 0</span>`,
-              );
-            }
-            consecutiveFailures = 0;
-          }
-        } else {
-          consecutiveFailures++;
-          if (debug) {
-            log(
-              `⚠️ <span style="color: #E67E22;">Action failed (${consecutiveFailures}/${maxConsecutiveFailures})</span>`,
-            );
-          } else {
-            log(
-              `⚠️ <span style="color: #E67E22;">Action failed, continuing...</span>`,
-            );
-          }
-        }
-      } else {
-        log(
-          `🎲 <span style="color: #9B59B6;">Temperature bypass - random action instead</span>`,
-        );
-        // Execute a random action instead
-        const randomResult = await executeRandomAction(
-          page,
-          hotZones,
-          persona,
-          log,
-        );
-        actionResults.push(randomResult);
-      }
+				// Handle success/failure based on circuit breaker config
+				if (result.success || result.skipped) {
+					if (resetOnSuccess) {
+						if (consecutiveFailures > 0 && debug) {
+							log(
+								`✅ <span style="color: #27AE60;">Success - resetting failure counter from ${consecutiveFailures} to 0</span>`
+							);
+						}
+						consecutiveFailures = 0;
+					}
+				} else {
+					consecutiveFailures++;
+					if (debug) {
+						log(
+							`⚠️ <span style="color: #E67E22;">Action failed (${consecutiveFailures}/${maxConsecutiveFailures})</span>`
+						);
+					} else {
+						log(`⚠️ <span style="color: #E67E22;">Action failed, continuing...</span>`);
+					}
+				}
+			} else {
+				log(`🎲 <span style="color: #9B59B6;">Temperature bypass - random action instead</span>`);
+				// Execute a random action instead
+				const randomResult = await executeRandomAction(page, hotZones, persona, log);
+				actionResults.push(randomResult);
+			}
 
-      // Check circuit breaker
-      if (consecutiveFailures >= maxConsecutiveFailures) {
-        circuitBreakerTriggered = true;
-        if (mode === "terminate") {
-          log(
-            `🛑 <span style="color: #E74C3C;">Circuit breaker triggered: ${consecutiveFailures} consecutive failures, stopping sequence</span>`,
-          );
-          break;
-        } else if (mode === "skip") {
-          log(
-            `⏭️ <span style="color: #F39C12;">Circuit breaker in skip mode: continuing despite failures</span>`,
-          );
-          // Reset counter to avoid repeated messages
-          consecutiveFailures = 0;
-        }
-      }
+			// Check circuit breaker
+			if (consecutiveFailures >= maxConsecutiveFailures) {
+				circuitBreakerTriggered = true;
+				if (mode === 'terminate') {
+					log(
+						`🛑 <span style="color: #E74C3C;">Circuit breaker triggered: ${consecutiveFailures} consecutive failures, stopping sequence</span>`
+					);
+					break;
+				} else if (mode === 'skip') {
+					log(`⏭️ <span style="color: #F39C12;">Circuit breaker in skip mode: continuing despite failures</span>`);
+					// Reset counter to avoid repeated messages
+					consecutiveFailures = 0;
+				}
+			}
 
-      // Add realistic delays and non-state-changing actions between sequence actions
-      await addHumanBehavior(page, hotZones, persona, log);
-    } catch (error) {
-      log(
-        `🚨 <span style="color: #E74C3C;">Sequence action error:</span> ${error.message}`,
-      );
-      let currentUrl = "unknown";
-      try {
-        currentUrl = await page.url();
-      } catch (urlError) {
-        // Ignore URL fetch errors
-      }
-      actionResults.push({
-        action: action.action,
-        selector: action.selector,
-        success: false,
-        error: error.message,
-        reason: "exception",
-        page_url: currentUrl,
-        timestamp: Date.now(),
-      });
-      consecutiveFailures++;
-    }
+			// Add realistic delays and non-state-changing actions between sequence actions
+			await addHumanBehavior(page, hotZones, persona, log);
+		} catch (error) {
+			log(`🚨 <span style="color: #E74C3C;">Sequence action error:</span> ${error.message}`);
+			let currentUrl = 'unknown';
+			try {
+				currentUrl = await page.url();
+			} catch (urlError) {
+				// Ignore URL fetch errors
+			}
+			actionResults.push({
+				action: action.action,
+				selector: action.selector,
+				success: false,
+				error: error.message,
+				reason: 'exception',
+				page_url: currentUrl,
+				timestamp: Date.now()
+			});
+			consecutiveFailures++;
+		}
 
-    // Break out early if we've hit too many failures (terminate mode only)
-    if (consecutiveFailures >= maxConsecutiveFailures && mode === "terminate") {
-      circuitBreakerTriggered = true;
-      break;
-    }
-  }
+		// Break out early if we've hit too many failures (terminate mode only)
+		if (consecutiveFailures >= maxConsecutiveFailures && mode === 'terminate') {
+			circuitBreakerTriggered = true;
+			break;
+		}
+	}
 
-  log(
-    `✅ <span style="color: #27AE60;">Sequence completed:</span> ${actionResults.length} actions executed`,
-  );
+	log(`✅ <span style="color: #27AE60;">Sequence completed:</span> ${actionResults.length} actions executed`);
 
-  // Return results with circuit breaker metadata
-  return {
-    actionResults,
-    circuitBreakerTriggered,
-    failedActions: actionResults.filter((a) => !a.success && !a.skipped),
-  };
+	// Return results with circuit breaker metadata
+	return {
+		actionResults,
+		circuitBreakerTriggered,
+		failedActions: actionResults.filter(a => !a.success && !a.skipped)
+	};
 }
 
 /**
@@ -207,262 +156,218 @@ export async function executeSequence(
  * @param {boolean} debug - Enable debug logging
  * @returns {Promise<Object>} Action result
  */
-async function executeSequenceAction(
-  page,
-  action,
-  hotZones,
-  log,
-  debug = false,
-) {
-  const {
-    action: actionType,
-    selector,
-    text,
-    value,
-    clicksPerGroup,
-    requireActive,
-    expectsNavigation,
-    navigationTimeout = 5000,
-  } = action;
-  const startTime = Date.now();
-  let currentUrl;
+async function executeSequenceAction(page, action, hotZones, log, debug = false) {
+	const {
+		action: actionType,
+		selector,
+		text,
+		value,
+		clicksPerGroup,
+		requireActive,
+		expectsNavigation,
+		navigationTimeout = 5000
+	} = action;
+	const startTime = Date.now();
+	let currentUrl;
 
-  try {
-    // Get current URL for error reporting
-    try {
-      currentUrl = await page.url();
-    } catch (urlError) {
-      currentUrl = "unknown";
-    }
+	try {
+		// Get current URL for error reporting
+		try {
+			currentUrl = await page.url();
+		} catch (urlError) {
+			currentUrl = 'unknown';
+		}
 
-    // Validate action has required fields
-    if (!actionType || !selector) {
-      throw new Error(`Invalid action: missing action type or selector`);
-    }
+		// Validate action has required fields
+		if (!actionType || !selector) {
+			throw new Error(`Invalid action: missing action type or selector`);
+		}
 
-    if (debug) {
-      log(
-        `🔍 <span style="color: #95A5A6;">Debug: Looking for element "${selector}" on ${currentUrl}</span>`,
-      );
-    }
+		if (debug) {
+			log(`🔍 <span style="color: #95A5A6;">Debug: Looking for element "${selector}" on ${currentUrl}</span>`);
+		}
 
-    // Special handling for fillOutForm - it finds multiple elements
-    if (actionType.toLowerCase() === "filloutform") {
-      const result = await executeFillOutForm(
-        page,
-        selector,
-        clicksPerGroup,
-        log,
-      );
-      const duration = Date.now() - startTime;
-      let pageUrl = "unknown";
-      try {
-        pageUrl = await page.url();
-      } catch (urlError) {
-        // Ignore URL fetch errors
-      }
-      return {
-        ...result,
-        action: actionType,
-        selector,
-        clicksPerGroup: clicksPerGroup || undefined,
-        duration,
-        timestamp: startTime,
-        page_url: pageUrl,
-      };
-    }
+		// Special handling for fillOutForm - it finds multiple elements
+		if (actionType.toLowerCase() === 'filloutform') {
+			const result = await executeFillOutForm(page, selector, clicksPerGroup, log);
+			const duration = Date.now() - startTime;
+			let pageUrl = 'unknown';
+			try {
+				pageUrl = await page.url();
+			} catch (urlError) {
+				// Ignore URL fetch errors
+			}
+			return {
+				...result,
+				action: actionType,
+				selector,
+				clicksPerGroup: clicksPerGroup || undefined,
+				duration,
+				timestamp: startTime,
+				page_url: pageUrl
+			};
+		}
 
-    // Wait for element to be available with timeout
-    const element = await waitForElement(page, selector, log, debug);
-    if (!element) {
-      if (debug) {
-        log(
-          `❌ <span style="color: #E74C3C;">Debug: Element not found after timeout</span>`,
-        );
-      }
-      throw new Error(`Element not found: ${selector}`);
-    }
+		// Wait for element to be available with timeout
+		const element = await waitForElement(page, selector, log, debug);
+		if (!element) {
+			if (debug) {
+				log(`❌ <span style="color: #E74C3C;">Debug: Element not found after timeout</span>`);
+			}
+			throw new Error(`Element not found: ${selector}`);
+		}
 
-    if (debug) {
-      log(
-        `✓ <span style="color: #27AE60;">Debug: Element found, preparing to interact</span>`,
-      );
-    }
+		if (debug) {
+			log(`✓ <span style="color: #27AE60;">Debug: Element found, preparing to interact</span>`);
+		}
 
-    // Handle requireActive flag for click actions
-    if (requireActive && actionType.toLowerCase() === "click") {
-      const isActive = await page.evaluate((el) => {
-        return !el.disabled && !el.classList.contains("disabled");
-      }, element);
-      if (!isActive) {
-        log(
-          `⏭️ <span style="color: #F39C12;">Skipping click:</span> ${selector} is not active`,
-        );
-        let pageUrl = "unknown";
-        try {
-          pageUrl = await page.url();
-        } catch (urlError) {
-          // Ignore URL fetch errors
-        }
-        return {
-          success: true,
-          skipped: true,
-          action: actionType,
-          selector,
-          duration: Date.now() - startTime,
-          timestamp: startTime,
-          page_url: pageUrl,
-        };
-      }
-    }
+		// Handle requireActive flag for click actions
+		if (requireActive && actionType.toLowerCase() === 'click') {
+			const isActive = await page.evaluate(el => {
+				return !el.disabled && !el.classList.contains('disabled');
+			}, element);
+			if (!isActive) {
+				log(`⏭️ <span style="color: #F39C12;">Skipping click:</span> ${selector} is not active`);
+				let pageUrl = 'unknown';
+				try {
+					pageUrl = await page.url();
+				} catch (urlError) {
+					// Ignore URL fetch errors
+				}
+				return {
+					success: true,
+					skipped: true,
+					action: actionType,
+					selector,
+					duration: Date.now() - startTime,
+					timestamp: startTime,
+					page_url: pageUrl
+				};
+			}
+		}
 
-    let result;
+		let result;
 
-    // Handle navigation expectations
-    if (expectsNavigation) {
-      if (debug) {
-        log(
-          `🧭 <span style="color: #3498DB;">Debug: Action expects navigation, setting up listeners</span>`,
-        );
-      }
-      // Set up navigation promise before executing action
-      const navigationPromise = page
-        .waitForNavigation({
-          timeout: navigationTimeout,
-          waitUntil: "domcontentloaded",
-        })
-        .catch((err) => {
-          if (debug) {
-            log(
-              `⚠️ <span style="color: #F39C12;">Debug: Navigation timeout or error: ${err.message}</span>`,
-            );
-          }
-          return null;
-        });
+		// Handle navigation expectations
+		if (expectsNavigation) {
+			if (debug) {
+				log(`🧭 <span style="color: #3498DB;">Debug: Action expects navigation, setting up listeners</span>`);
+			}
+			// Set up navigation promise before executing action
+			const navigationPromise = page
+				.waitForNavigation({
+					timeout: navigationTimeout,
+					waitUntil: 'domcontentloaded'
+				})
+				.catch(err => {
+					if (debug) {
+						log(`⚠️ <span style="color: #F39C12;">Debug: Navigation timeout or error: ${err.message}</span>`);
+					}
+					return null;
+				});
 
-      // Execute the action
-      switch (actionType.toLowerCase()) {
-        case "click":
-          result = await executeClick(page, element, selector, log, debug);
-          break;
-        case "type":
-          if (!text) throw new Error("Type action requires text field");
-          result = await executeType(page, element, selector, text, log, debug);
-          break;
-        case "select":
-          if (!value) throw new Error("Select action requires value field");
-          result = await executeSelect(
-            page,
-            element,
-            selector,
-            value,
-            log,
-            debug,
-          );
-          break;
-        default:
-          throw new Error(`Unsupported action type: ${actionType}`);
-      }
+			// Execute the action
+			switch (actionType.toLowerCase()) {
+				case 'click':
+					result = await executeClick(page, element, selector, log, debug);
+					break;
+				case 'type':
+					if (!text) throw new Error('Type action requires text field');
+					result = await executeType(page, element, selector, text, log, debug);
+					break;
+				case 'select':
+					if (!value) throw new Error('Select action requires value field');
+					result = await executeSelect(page, element, selector, value, log, debug);
+					break;
+				default:
+					throw new Error(`Unsupported action type: ${actionType}`);
+			}
 
-      // Wait for navigation to complete
-      await navigationPromise;
-      let newUrl = "unknown";
-      try {
-        newUrl = await page.url();
-      } catch (urlError) {
-        // Ignore URL fetch errors
-      }
-      if (debug) {
-        log(
-          `🧭 <span style="color: #27AE60;">Debug: Navigation completed to ${newUrl}</span>`,
-        );
-      }
-    } else {
-      // Normal execution without navigation handling
-      switch (actionType.toLowerCase()) {
-        case "click":
-          result = await executeClick(page, element, selector, log, debug);
-          break;
-        case "type":
-          if (!text) throw new Error("Type action requires text field");
-          result = await executeType(page, element, selector, text, log, debug);
-          break;
-        case "select":
-          if (!value) throw new Error("Select action requires value field");
-          result = await executeSelect(
-            page,
-            element,
-            selector,
-            value,
-            log,
-            debug,
-          );
-          break;
-        default:
-          throw new Error(`Unsupported action type: ${actionType}`);
-      }
-    }
+			// Wait for navigation to complete
+			await navigationPromise;
+			let newUrl = 'unknown';
+			try {
+				newUrl = await page.url();
+			} catch (urlError) {
+				// Ignore URL fetch errors
+			}
+			if (debug) {
+				log(`🧭 <span style="color: #27AE60;">Debug: Navigation completed to ${newUrl}</span>`);
+			}
+		} else {
+			// Normal execution without navigation handling
+			switch (actionType.toLowerCase()) {
+				case 'click':
+					result = await executeClick(page, element, selector, log, debug);
+					break;
+				case 'type':
+					if (!text) throw new Error('Type action requires text field');
+					result = await executeType(page, element, selector, text, log, debug);
+					break;
+				case 'select':
+					if (!value) throw new Error('Select action requires value field');
+					result = await executeSelect(page, element, selector, value, log, debug);
+					break;
+				default:
+					throw new Error(`Unsupported action type: ${actionType}`);
+			}
+		}
 
-    const duration = Date.now() - startTime;
-    let pageUrl = "unknown";
-    try {
-      pageUrl = await page.url();
-    } catch (urlError) {
-      // Ignore URL fetch errors
-    }
-    return {
-      ...result,
-      action: actionType,
-      selector,
-      text: text || undefined,
-      value: value || undefined,
-      duration,
-      timestamp: startTime,
-      page_url: pageUrl,
-    };
-  } catch (error) {
-    const duration = Date.now() - startTime;
-    let pageUrl = currentUrl || "unknown";
-    try {
-      pageUrl = await page.url();
-    } catch (urlError) {
-      // Use currentUrl or fallback to 'unknown'
-    }
+		const duration = Date.now() - startTime;
+		let pageUrl = 'unknown';
+		try {
+			pageUrl = await page.url();
+		} catch (urlError) {
+			// Ignore URL fetch errors
+		}
+		return {
+			...result,
+			action: actionType,
+			selector,
+			text: text || undefined,
+			value: value || undefined,
+			duration,
+			timestamp: startTime,
+			page_url: pageUrl
+		};
+	} catch (error) {
+		const duration = Date.now() - startTime;
+		let pageUrl = currentUrl || 'unknown';
+		try {
+			pageUrl = await page.url();
+		} catch (urlError) {
+			// Use currentUrl or fallback to 'unknown'
+		}
 
-    // Determine specific failure reason
-    let reason = "unknown";
-    if (error.message.includes("not found")) {
-      reason = "selector_not_found";
-    } else if (error.message.includes("timeout")) {
-      reason = "timeout";
-    } else if (
-      error.message.includes("visible") ||
-      error.message.includes("hidden")
-    ) {
-      reason = "element_not_visible";
-    } else if (error.message.includes("detached")) {
-      reason = "element_detached";
-    }
+		// Determine specific failure reason
+		let reason = 'unknown';
+		if (error.message.includes('not found')) {
+			reason = 'selector_not_found';
+		} else if (error.message.includes('timeout')) {
+			reason = 'timeout';
+		} else if (error.message.includes('visible') || error.message.includes('hidden')) {
+			reason = 'element_not_visible';
+		} else if (error.message.includes('detached')) {
+			reason = 'element_detached';
+		}
 
-    if (debug) {
-      log(
-        `❌ <span style="color: #E74C3C;">Debug: Action failed with reason: ${reason}</span>`,
-      );
-    }
+		if (debug) {
+			log(`❌ <span style="color: #E74C3C;">Debug: Action failed with reason: ${reason}</span>`);
+		}
 
-    return {
-      action: actionType,
-      selector,
-      text: text || undefined,
-      value: value || undefined,
-      success: false,
-      error: error.message,
-      reason,
-      duration,
-      timestamp: startTime,
-      page_url: pageUrl,
-    };
-  }
+		return {
+			action: actionType,
+			selector,
+			text: text || undefined,
+			value: value || undefined,
+			success: false,
+			error: error.message,
+			reason,
+			duration,
+			timestamp: startTime,
+			page_url: pageUrl
+		};
+	}
 }
 
 /**
@@ -474,67 +379,50 @@ async function executeSequenceAction(
  * @returns {Promise<ElementHandle|null>} Element handle or null
  */
 async function waitForElement(page, selector, log, debug = false) {
-  try {
-    if (debug) {
-      log(
-        `🔍 <span style="color: #95A5A6;">Debug: Waiting for selector with 5s timeout...</span>`,
-      );
-    }
-    // Wait for element with timeout
-    await page.waitForSelector(selector, { timeout: 5000, visible: true });
-    const element = await page.$(selector);
-    if (debug && element) {
-      log(
-        `✓ <span style="color: #27AE60;">Debug: Element found and visible</span>`,
-      );
-    }
-    return element;
-  } catch (error) {
-    // Try alternative selectors or fallback strategies
-    if (debug) {
-      log(
-        `🔍 <span style="color: #F39C12;">Debug: Initial wait failed, trying alternatives (${error.message})</span>`,
-      );
-    } else {
-      log(
-        `🔍 <span style="color: #F39C12;">Element not immediately found, trying alternatives...</span>`,
-      );
-    }
+	try {
+		if (debug) {
+			log(`🔍 <span style="color: #95A5A6;">Debug: Waiting for selector with 5s timeout...</span>`);
+		}
+		// Wait for element with timeout
+		await page.waitForSelector(selector, { timeout: 5000, visible: true });
+		const element = await page.$(selector);
+		if (debug && element) {
+			log(`✓ <span style="color: #27AE60;">Debug: Element found and visible</span>`);
+		}
+		return element;
+	} catch (error) {
+		// Try alternative selectors or fallback strategies
+		if (debug) {
+			log(`🔍 <span style="color: #F39C12;">Debug: Initial wait failed, trying alternatives (${error.message})</span>`);
+		} else {
+			log(`🔍 <span style="color: #F39C12;">Element not immediately found, trying alternatives...</span>`);
+		}
 
-    // Try waiting a bit longer
-    await sleep(1000);
-    const element = await page.$(selector);
-    if (element) {
-      // Check if element is visible
-      const isVisible = await page.evaluate((el) => {
-        const rect = el.getBoundingClientRect();
-        const style = window.getComputedStyle(el);
-        return (
-          rect.width > 0 &&
-          rect.height > 0 &&
-          style.visibility !== "hidden" &&
-          style.display !== "none"
-        );
-      }, element);
+		// Try waiting a bit longer
+		await sleep(1000);
+		const element = await page.$(selector);
+		if (element) {
+			// Check if element is visible
+			const isVisible = await page.evaluate(el => {
+				const rect = el.getBoundingClientRect();
+				const style = window.getComputedStyle(el);
+				return rect.width > 0 && rect.height > 0 && style.visibility !== 'hidden' && style.display !== 'none';
+			}, element);
 
-      if (debug) {
-        log(
-          `🔍 <span style="color: #95A5A6;">Debug: Element exists, visibility=${isVisible}</span>`,
-        );
-      }
+			if (debug) {
+				log(`🔍 <span style="color: #95A5A6;">Debug: Element exists, visibility=${isVisible}</span>`);
+			}
 
-      if (isVisible) {
-        return element;
-      }
-    }
+			if (isVisible) {
+				return element;
+			}
+		}
 
-    if (debug) {
-      log(
-        `❌ <span style="color: #E74C3C;">Debug: Element not found or not visible after all attempts</span>`,
-      );
-    }
-    return null;
-  }
+		if (debug) {
+			log(`❌ <span style="color: #E74C3C;">Debug: Element not found or not visible after all attempts</span>`);
+		}
+		return null;
+	}
 }
 
 /**
@@ -547,40 +435,36 @@ async function waitForElement(page, selector, log, debug = false) {
  * @returns {Promise<Object>} Action result
  */
 async function executeClick(page, element, selector, log, debug = false) {
-  try {
-    // Scroll element into view if needed
-    await element.scrollIntoViewIfNeeded();
-    await sleep(randomBetween(100, 300));
+	try {
+		// Scroll element into view if needed
+		await element.scrollIntoViewIfNeeded();
+		await sleep(randomBetween(100, 300));
 
-    // Get element bounds for natural clicking
-    const box = await element.boundingBox();
-    if (!box) {
-      throw new Error("Element has no bounding box");
-    }
+		// Get element bounds for natural clicking
+		const box = await element.boundingBox();
+		if (!box) {
+			throw new Error('Element has no bounding box');
+		}
 
-    // Add some randomness to click position (human-like behavior)
-    const fuzziness = 0.35; // ±35%
-    const clickX =
-      box.x + box.width * (0.5 + (Math.random() - 0.5) * fuzziness);
-    const clickY =
-      box.y + box.height * (0.5 + (Math.random() - 0.5) * fuzziness);
+		// Add some randomness to click position (human-like behavior)
+		const fuzziness = 0.35; // ±35%
+		const clickX = box.x + box.width * (0.5 + (Math.random() - 0.5) * fuzziness);
+		const clickY = box.y + box.height * (0.5 + (Math.random() - 0.5) * fuzziness);
 
-    // Move mouse naturally to the element first
-    await page.mouse.move(clickX, clickY);
-    await sleep(randomBetween(50, 150));
+		// Move mouse naturally to the element first
+		await page.mouse.move(clickX, clickY);
+		await sleep(randomBetween(50, 150));
 
-    // Perform the click
-    await page.mouse.click(clickX, clickY);
-    await sleep(randomBetween(100, 300));
+		// Perform the click
+		await page.mouse.click(clickX, clickY);
+		await sleep(randomBetween(100, 300));
 
-    log(`🖱️ <span style="color: #2ECC71;">Clicked:</span> ${selector}`);
-    return { success: true };
-  } catch (error) {
-    log(
-      `❌ <span style="color: #E74C3C;">Click failed:</span> ${selector} - ${error.message}`,
-    );
-    return { success: false, error: error.message };
-  }
+		log(`🖱️ <span style="color: #2ECC71;">Clicked:</span> ${selector}`);
+		return { success: true };
+	} catch (error) {
+		log(`❌ <span style="color: #E74C3C;">Click failed:</span> ${selector} - ${error.message}`);
+		return { success: false, error: error.message };
+	}
 }
 
 /**
@@ -594,29 +478,25 @@ async function executeClick(page, element, selector, log, debug = false) {
  * @returns {Promise<Object>} Action result
  */
 async function executeType(page, element, selector, text, log, debug = false) {
-  try {
-    // Scroll element into view and focus
-    await element.scrollIntoViewIfNeeded();
-    await sleep(randomBetween(100, 300));
+	try {
+		// Scroll element into view and focus
+		await element.scrollIntoViewIfNeeded();
+		await sleep(randomBetween(100, 300));
 
-    // Clear existing content first
-    await element.click({ clickCount: 3 }); // Triple-click to select all
-    await sleep(randomBetween(50, 150));
+		// Clear existing content first
+		await element.click({ clickCount: 3 }); // Triple-click to select all
+		await sleep(randomBetween(50, 150));
 
-    // Type text with human-like delays
-    await element.type(text, { delay: randomBetween(50, 150) });
-    await sleep(randomBetween(100, 300));
+		// Type text with human-like delays
+		await element.type(text, { delay: randomBetween(50, 150) });
+		await sleep(randomBetween(100, 300));
 
-    log(
-      `⌨️ <span style="color: #3498DB;">Typed:</span> "${text}" into ${selector}`,
-    );
-    return { success: true };
-  } catch (error) {
-    log(
-      `❌ <span style="color: #E74C3C;">Type failed:</span> ${selector} - ${error.message}`,
-    );
-    return { success: false, error: error.message };
-  }
+		log(`⌨️ <span style="color: #3498DB;">Typed:</span> "${text}" into ${selector}`);
+		return { success: true };
+	} catch (error) {
+		log(`❌ <span style="color: #E74C3C;">Type failed:</span> ${selector} - ${error.message}`);
+		return { success: false, error: error.message };
+	}
 }
 
 /**
@@ -629,33 +509,22 @@ async function executeType(page, element, selector, text, log, debug = false) {
  * @param {boolean} debug - Enable debug logging
  * @returns {Promise<Object>} Action result
  */
-async function executeSelect(
-  page,
-  element,
-  selector,
-  value,
-  log,
-  debug = false,
-) {
-  try {
-    // Scroll element into view
-    await element.scrollIntoViewIfNeeded();
-    await sleep(randomBetween(100, 300));
+async function executeSelect(page, element, selector, value, log, debug = false) {
+	try {
+		// Scroll element into view
+		await element.scrollIntoViewIfNeeded();
+		await sleep(randomBetween(100, 300));
 
-    // Try to select by value
-    await element.select(value);
-    await sleep(randomBetween(100, 300));
+		// Try to select by value
+		await element.select(value);
+		await sleep(randomBetween(100, 300));
 
-    log(
-      `🔽 <span style="color: #9B59B6;">Selected:</span> "${value}" in ${selector}`,
-    );
-    return { success: true };
-  } catch (error) {
-    log(
-      `❌ <span style="color: #E74C3C;">Select failed:</span> ${selector} - ${error.message}`,
-    );
-    return { success: false, error: error.message };
-  }
+		log(`🔽 <span style="color: #9B59B6;">Selected:</span> "${value}" in ${selector}`);
+		return { success: true };
+	} catch (error) {
+		log(`❌ <span style="color: #E74C3C;">Select failed:</span> ${selector} - ${error.message}`);
+		return { success: false, error: error.message };
+	}
 }
 
 /**
@@ -668,108 +537,81 @@ async function executeSelect(
  * @returns {Promise<Object>} Action result
  */
 async function executeFillOutForm(page, selector, clicksPerGroup = 2, log) {
-  try {
-    // Find all matching elements
-    const elements = await page.$$(selector);
+	try {
+		// Find all matching elements
+		const elements = await page.$$(selector);
 
-    if (elements.length === 0) {
-      log(
-        `⚠️ <span style="color: #F39C12;">No elements found matching:</span> ${selector}`,
-      );
-      return {
-        success: false,
-        error: "No elements found",
-        elementsProcessed: 0,
-      };
-    }
+		if (elements.length === 0) {
+			log(`⚠️ <span style="color: #F39C12;">No elements found matching:</span> ${selector}`);
+			return {
+				success: false,
+				error: 'No elements found',
+				elementsProcessed: 0
+			};
+		}
 
-    log(
-      `📝 <span style="color: #3498DB;">Filling out form:</span> ${elements.length} element(s) matching ${selector}`,
-    );
-    let successCount = 0;
+		log(`📝 <span style="color: #3498DB;">Filling out form:</span> ${elements.length} element(s) matching ${selector}`);
+		let successCount = 0;
 
-    for (const [index, element] of elements.entries()) {
-      try {
-        // Determine element type
-        const elementInfo = await page.evaluate((el) => {
-          const tagName = el.tagName.toLowerCase();
-          const type = el.type || tagName;
-          const role = el.getAttribute("role");
+		for (const [index, element] of elements.entries()) {
+			try {
+				// Determine element type
+				const elementInfo = await page.evaluate(el => {
+					const tagName = el.tagName.toLowerCase();
+					const type = el.type || tagName;
+					const role = el.getAttribute('role');
 
-          // For radiogroups, find all radio buttons within
-          if (role === "radiogroup") {
-            const radios = el.querySelectorAll(
-              'input[type="radio"], [role="radio"]',
-            );
-            return {
-              type: "radiogroup",
-              role,
-              radioCount: radios.length,
-              tagName,
-            };
-          }
+					// For radiogroups, find all radio buttons within
+					if (role === 'radiogroup') {
+						const radios = el.querySelectorAll('input[type="radio"], [role="radio"]');
+						return {
+							type: 'radiogroup',
+							role,
+							radioCount: radios.length,
+							tagName
+						};
+					}
 
-          return { type, role, tagName };
-        }, element);
+					return { type, role, tagName };
+				}, element);
 
-        // Use shared utilities from forms.js
-        let success = false;
+				// Use shared utilities from forms.js
+				let success = false;
 
-        if (elementInfo.role === "radiogroup") {
-          log(
-            `🔘 <span style="color: #9B59B6;">Radio group ${index + 1}:</span> ${elementInfo.radioCount} options, clicking ${clicksPerGroup} times`,
-          );
-          success = await fillRadioGroup(page, element, clicksPerGroup, log);
-        } else if (
-          elementInfo.type === "checkbox" ||
-          elementInfo.role === "checkbox"
-        ) {
-          success = await toggleCheckbox(page, element, log);
-          if (success)
-            log(
-              `☑️ <span style="color: #2ECC71;">Toggled checkbox</span> ${index + 1}`,
-            );
-        } else if (elementInfo.tagName === "select") {
-          success = await fillSelectDropdown(page, element, null, log);
-          if (success)
-            log(
-              `🔽 <span style="color: #9B59B6;">Selected option</span> in dropdown ${index + 1}`,
-            );
-        } else if (
-          elementInfo.tagName === "textarea" ||
-          elementInfo.tagName === "input"
-        ) {
-          success = await fillTextInput(page, element, null, log);
-          if (success)
-            log(
-              `⌨️ <span style="color: #3498DB;">Typed text</span> in field ${index + 1}`,
-            );
-        }
+				if (elementInfo.role === 'radiogroup') {
+					log(
+						`🔘 <span style="color: #9B59B6;">Radio group ${index + 1}:</span> ${elementInfo.radioCount} options, clicking ${clicksPerGroup} times`
+					);
+					success = await fillRadioGroup(page, element, clicksPerGroup, log);
+				} else if (elementInfo.type === 'checkbox' || elementInfo.role === 'checkbox') {
+					success = await toggleCheckbox(page, element, log);
+					if (success) log(`☑️ <span style="color: #2ECC71;">Toggled checkbox</span> ${index + 1}`);
+				} else if (elementInfo.tagName === 'select') {
+					success = await fillSelectDropdown(page, element, null, log);
+					if (success) log(`🔽 <span style="color: #9B59B6;">Selected option</span> in dropdown ${index + 1}`);
+				} else if (elementInfo.tagName === 'textarea' || elementInfo.tagName === 'input') {
+					success = await fillTextInput(page, element, null, log);
+					if (success) log(`⌨️ <span style="color: #3498DB;">Typed text</span> in field ${index + 1}`);
+				}
 
-        if (success) {
-          successCount++;
-        }
-      } catch (elementError) {
-        log(
-          `⚠️ <span style="color: #F39C12;">Error with element ${index + 1}:</span> ${elementError.message}`,
-        );
-      }
-    }
+				if (success) {
+					successCount++;
+				}
+			} catch (elementError) {
+				log(`⚠️ <span style="color: #F39C12;">Error with element ${index + 1}:</span> ${elementError.message}`);
+			}
+		}
 
-    log(
-      `✅ <span style="color: #27AE60;">Form filled:</span> ${successCount}/${elements.length} elements processed`,
-    );
-    return {
-      success: successCount > 0,
-      elementsProcessed: successCount,
-      totalElements: elements.length,
-    };
-  } catch (error) {
-    log(
-      `❌ <span style="color: #E74C3C;">Fill form failed:</span> ${error.message}`,
-    );
-    return { success: false, error: error.message, elementsProcessed: 0 };
-  }
+		log(`✅ <span style="color: #27AE60;">Form filled:</span> ${successCount}/${elements.length} elements processed`);
+		return {
+			success: successCount > 0,
+			elementsProcessed: successCount,
+			totalElements: elements.length
+		};
+	} catch (error) {
+		log(`❌ <span style="color: #E74C3C;">Fill form failed:</span> ${error.message}`);
+		return { success: false, error: error.message, elementsProcessed: 0 };
+	}
 }
 
 /**
@@ -781,31 +623,30 @@ async function executeFillOutForm(page, selector, clicksPerGroup = 2, log) {
  * @returns {Promise<Object>} Action result
  */
 async function executeRandomAction(page, hotZones, persona, log) {
-  const randomActions = [
-    () => exploratoryClick(page, log),
-    () => naturalMouseMovement(page, hotZones, log),
-    () => intelligentScroll(page, hotZones, log),
-    () => interactWithForms(page, log),
-  ];
+	const randomActions = [
+		() => exploratoryClick(page, log),
+		() => naturalMouseMovement(page, hotZones, log),
+		() => intelligentScroll(page, hotZones, log),
+		() => interactWithForms(page, log)
+	];
 
-  const randomAction =
-    randomActions[Math.floor(Math.random() * randomActions.length)];
+	const randomAction = randomActions[Math.floor(Math.random() * randomActions.length)];
 
-  try {
-    await randomAction();
-    return {
-      action: "random",
-      success: true,
-      timestamp: Date.now(),
-    };
-  } catch (error) {
-    return {
-      action: "random",
-      success: false,
-      error: error.message,
-      timestamp: Date.now(),
-    };
-  }
+	try {
+		await randomAction();
+		return {
+			action: 'random',
+			success: true,
+			timestamp: Date.now()
+		};
+	} catch (error) {
+		return {
+			action: 'random',
+			success: false,
+			error: error.message,
+			timestamp: Date.now()
+		};
+	}
 }
 
 /**
@@ -816,26 +657,25 @@ async function executeRandomAction(page, hotZones, persona, log) {
  * @param {Function} log - Logging function
  */
 async function addHumanBehavior(page, hotZones, persona, log) {
-  // Random delay between actions (500ms to 2000ms)
-  const baseDelay = randomBetween(500, 2000);
-  await sleep(baseDelay);
+	// Random delay between actions (500ms to 2000ms)
+	const baseDelay = randomBetween(500, 2000);
+	await sleep(baseDelay);
 
-  // Occasionally add non-state-changing actions (30% chance)
-  if (Math.random() < 0.3) {
-    const behaviorActions = [
-      () => naturalMouseMovement(page, hotZones, log),
-      () => intelligentScroll(page, hotZones, log),
-      () => wait(),
-    ];
+	// Occasionally add non-state-changing actions (30% chance)
+	if (Math.random() < 0.3) {
+		const behaviorActions = [
+			() => naturalMouseMovement(page, hotZones, log),
+			() => intelligentScroll(page, hotZones, log),
+			() => wait()
+		];
 
-    const behaviorAction =
-      behaviorActions[Math.floor(Math.random() * behaviorActions.length)];
-    try {
-      await behaviorAction();
-    } catch (error) {
-      // Ignore errors in non-essential behavior actions
-    }
-  }
+		const behaviorAction = behaviorActions[Math.floor(Math.random() * behaviorActions.length)];
+		try {
+			await behaviorAction();
+		} catch (error) {
+			// Ignore errors in non-essential behavior actions
+		}
+	}
 }
 
 /**
@@ -844,90 +684,73 @@ async function addHumanBehavior(page, hotZones, persona, log) {
  * @returns {import('../index.js').ValidationResult} Validation result with {valid: boolean, errors: string[]}
  */
 export function validateSequence(sequenceSpec) {
-  const errors = [];
+	const errors = [];
 
-  if (!sequenceSpec || typeof sequenceSpec !== "object") {
-    return { valid: false, errors: ["Sequence must be an object"] };
-  }
+	if (!sequenceSpec || typeof sequenceSpec !== 'object') {
+		return { valid: false, errors: ['Sequence must be an object'] };
+	}
 
-  const {
-    description,
-    temperature,
-    "chaos-range": chaosRange,
-    actions,
-  } = sequenceSpec;
+	const { description, temperature, 'chaos-range': chaosRange, actions } = sequenceSpec;
 
-  // Validate description
-  if (description && typeof description !== "string") {
-    errors.push("Description must be a string");
-  }
+	// Validate description
+	if (description && typeof description !== 'string') {
+		errors.push('Description must be a string');
+	}
 
-  // Validate temperature
-  if (temperature !== undefined) {
-    if (
-      typeof temperature !== "number" ||
-      temperature < 0 ||
-      temperature > 10
-    ) {
-      errors.push("Temperature must be a number between 0 and 10");
-    }
-  }
+	// Validate temperature
+	if (temperature !== undefined) {
+		if (typeof temperature !== 'number' || temperature < 0 || temperature > 10) {
+			errors.push('Temperature must be a number between 0 and 10');
+		}
+	}
 
-  // Validate chaos-range
-  if (chaosRange !== undefined) {
-    if (
-      !Array.isArray(chaosRange) ||
-      chaosRange.length !== 2 ||
-      typeof chaosRange[0] !== "number" ||
-      typeof chaosRange[1] !== "number"
-    ) {
-      errors.push("Chaos-range must be an array of two numbers");
-    } else if (chaosRange[0] > chaosRange[1]) {
-      errors.push(
-        "Chaos-range first value must be less than or equal to second value",
-      );
-    }
-  }
+	// Validate chaos-range
+	if (chaosRange !== undefined) {
+		if (
+			!Array.isArray(chaosRange) ||
+			chaosRange.length !== 2 ||
+			typeof chaosRange[0] !== 'number' ||
+			typeof chaosRange[1] !== 'number'
+		) {
+			errors.push('Chaos-range must be an array of two numbers');
+		} else if (chaosRange[0] > chaosRange[1]) {
+			errors.push('Chaos-range first value must be less than or equal to second value');
+		}
+	}
 
-  // Validate actions
-  if (!actions || !Array.isArray(actions)) {
-    errors.push("Actions must be an array");
-  } else {
-    actions.forEach((action, index) => {
-      if (!action || typeof action !== "object") {
-        errors.push(`Action ${index + 1} must be an object`);
-        return;
-      }
+	// Validate actions
+	if (!actions || !Array.isArray(actions)) {
+		errors.push('Actions must be an array');
+	} else {
+		actions.forEach((action, index) => {
+			if (!action || typeof action !== 'object') {
+				errors.push(`Action ${index + 1} must be an object`);
+				return;
+			}
 
-      const { action: actionType, selector, text, value } = action;
+			const { action: actionType, selector, text, value } = action;
 
-      if (!actionType || typeof actionType !== "string") {
-        errors.push(`Action ${index + 1} must have a valid action type`);
-      } else if (
-        !["click", "type", "select", "filloutform"].includes(
-          actionType.toLowerCase(),
-        )
-      ) {
-        errors.push(
-          `Action ${index + 1} has unsupported action type: ${actionType}`,
-        );
-      }
+			if (!actionType || typeof actionType !== 'string') {
+				errors.push(`Action ${index + 1} must have a valid action type`);
+			} else if (!['click', 'type', 'select', 'filloutform'].includes(actionType.toLowerCase())) {
+				errors.push(`Action ${index + 1} has unsupported action type: ${actionType}`);
+			}
 
-      if (!selector || typeof selector !== "string") {
-        errors.push(`Action ${index + 1} must have a valid selector`);
-      }
+			if (!selector || typeof selector !== 'string') {
+				errors.push(`Action ${index + 1} must have a valid selector`);
+			}
 
-      if (actionType === "type" && (!text || typeof text !== "string")) {
-        errors.push(`Action ${index + 1} (type) must have a text field`);
-      }
+			if (actionType === 'type' && (!text || typeof text !== 'string')) {
+				errors.push(`Action ${index + 1} (type) must have a text field`);
+			}
 
-      if (actionType === "select" && (!value || typeof value !== "string")) {
-        errors.push(`Action ${index + 1} (select) must have a value field`);
-      }
-    });
-  }
+			if (actionType === 'select' && (!value || typeof value !== 'string')) {
+				errors.push(`Action ${index + 1} (select) must have a value field`);
+			}
+		});
+	}
 
-  return { valid: errors.length === 0, errors };
+	return { valid: errors.length === 0, errors };
 }
 
 /**
@@ -936,25 +759,25 @@ export function validateSequence(sequenceSpec) {
  * @returns {import('../index.js').ValidationResult} Validation result with {valid: boolean, errors: string[]}
  */
 export function validateSequences(sequences) {
-  if (!sequences || typeof sequences !== "object") {
-    return { valid: false, errors: ["Sequences must be an object"] };
-  }
+	if (!sequences || typeof sequences !== 'object') {
+		return { valid: false, errors: ['Sequences must be an object'] };
+	}
 
-  const allErrors = [];
-  const sequenceNames = Object.keys(sequences);
+	const allErrors = [];
+	const sequenceNames = Object.keys(sequences);
 
-  if (sequenceNames.length === 0) {
-    return { valid: false, errors: ["Sequences object cannot be empty"] };
-  }
+	if (sequenceNames.length === 0) {
+		return { valid: false, errors: ['Sequences object cannot be empty'] };
+	}
 
-  sequenceNames.forEach((name) => {
-    const validation = validateSequence(sequences[name]);
-    if (!validation.valid) {
-      validation.errors.forEach((error) => {
-        allErrors.push(`Sequence "${name}": ${error}`);
-      });
-    }
-  });
+	sequenceNames.forEach(name => {
+		const validation = validateSequence(sequences[name]);
+		if (!validation.valid) {
+			validation.errors.forEach(error => {
+				allErrors.push(`Sequence "${name}": ${error}`);
+			});
+		}
+	});
 
-  return { valid: allErrors.length === 0, errors: allErrors };
+	return { valid: allErrors.length === 0, errors: allErrors };
 }

--- a/sequences/sequence-api-and-creation-guide.md
+++ b/sequences/sequence-api-and-creation-guide.md
@@ -88,34 +88,34 @@ The key is to get an ordered list of click events from your single walkthrough s
 
 ```json
 {
-  "my-funnel": {
-    "description": "Human-readable description of this funnel",
-    "temperature": 8,
-    "chaos-range": [1, 2],
-    "debug": false,
-    "circuitBreaker": {
-      "maxFailures": 5,
-      "resetOnSuccess": true,
-      "mode": "skip"
-    },
-    "actions": [
-      { "action": "click", "selector": "#addToCart" },
-      { "action": "type", "selector": "#email", "text": "user@example.com" },
-      { "action": "select", "selector": "#shipping", "value": "express" },
-      {
-        "action": "fillOutForm",
-        "selector": "[role=radiogroup]",
-        "clicksPerGroup": 2
-      },
-      {
-        "action": "click",
-        "selector": "#submit",
-        "requireActive": true,
-        "expectsNavigation": true,
-        "navigationTimeout": 10000
-      }
-    ]
-  }
+	"my-funnel": {
+		"description": "Human-readable description of this funnel",
+		"temperature": 8,
+		"chaos-range": [1, 2],
+		"debug": false,
+		"circuitBreaker": {
+			"maxFailures": 5,
+			"resetOnSuccess": true,
+			"mode": "skip"
+		},
+		"actions": [
+			{ "action": "click", "selector": "#addToCart" },
+			{ "action": "type", "selector": "#email", "text": "user@example.com" },
+			{ "action": "select", "selector": "#shipping", "value": "express" },
+			{
+				"action": "fillOutForm",
+				"selector": "[role=radiogroup]",
+				"clicksPerGroup": 2
+			},
+			{
+				"action": "click",
+				"selector": "#submit",
+				"requireActive": true,
+				"expectsNavigation": true,
+				"navigationTimeout": 10000
+			}
+		]
+	}
 }
 ```
 
@@ -144,17 +144,15 @@ This script reads a raw export file (newline-delimited JSON), filters to `$mp_cl
 // convert-autocapture-to-sequence.js
 // Usage: node convert-autocapture-to-sequence.js <exported-events.json> > my-sequence.json
 
-import { readFileSync } from "fs";
+import { readFileSync } from 'fs';
 
-const raw = readFileSync(process.argv[2], "utf-8").trim();
+const raw = readFileSync(process.argv[2], 'utf-8').trim();
 
 // Raw export is newline-delimited JSON (one object per line)
-const events = raw.split("\n").map((line) => JSON.parse(line));
+const events = raw.split('\n').map(line => JSON.parse(line));
 
 // Keep only $mp_click, skip page views, page leaves, rage clicks, session records
-const clicks = events
-  .filter((e) => e.event === "$mp_click")
-  .sort((a, b) => a.properties.time - b.properties.time);
+const clicks = events.filter(e => e.event === '$mp_click').sort((a, b) => a.properties.time - b.properties.time);
 
 /**
  * Build the best CSS selector from the $elements hierarchy.
@@ -166,45 +164,45 @@ const clicks = events
  *   4. Last resort: .class1.class2 or just the tag name
  */
 function buildSelector(elements) {
-  if (!elements || elements.length === 0) return null;
+	if (!elements || elements.length === 0) return null;
 
-  const target = elements[0];
+	const target = elements[0];
 
-  // 1. Target has an ID -- best case
-  if (target.$id) {
-    return `#${target.$id}`;
-  }
+	// 1. Target has an ID -- best case
+	if (target.$id) {
+		return `#${target.$id}`;
+	}
 
-  // 2. Target has a role attribute -- often more stable than classes
-  const targetRole = target["$attr-role"];
-  if (targetRole) {
-    // Walk up to find a scoping ancestor with an ID
-    for (let i = 1; i < elements.length; i++) {
-      if (elements[i].$id) {
-        return `#${elements[i].$id} [role="${targetRole}"]`;
-      }
-    }
-    return `[role="${targetRole}"]`;
-  }
+	// 2. Target has a role attribute -- often more stable than classes
+	const targetRole = target['$attr-role'];
+	if (targetRole) {
+		// Walk up to find a scoping ancestor with an ID
+		for (let i = 1; i < elements.length; i++) {
+			if (elements[i].$id) {
+				return `#${elements[i].$id} [role="${targetRole}"]`;
+			}
+		}
+		return `[role="${targetRole}"]`;
+	}
 
-  // 3. Target has classes -- scope under nearest ancestor with ID
-  const targetClasses = (target.$classes || []).filter((c) => c && c.trim());
-  const targetClassStr = targetClasses.map((c) => `.${c}`).join("");
+	// 3. Target has classes -- scope under nearest ancestor with ID
+	const targetClasses = (target.$classes || []).filter(c => c && c.trim());
+	const targetClassStr = targetClasses.map(c => `.${c}`).join('');
 
-  for (let i = 1; i < elements.length; i++) {
-    if (elements[i].$id) {
-      if (targetClassStr) {
-        return `#${elements[i].$id} ${targetClassStr}`;
-      }
-      return `#${elements[i].$id} ${target.$tag_name}`;
-    }
-  }
+	for (let i = 1; i < elements.length; i++) {
+		if (elements[i].$id) {
+			if (targetClassStr) {
+				return `#${elements[i].$id} ${targetClassStr}`;
+			}
+			return `#${elements[i].$id} ${target.$tag_name}`;
+		}
+	}
 
-  // 4. No ancestor ID found -- use classes or tag name
-  if (targetClassStr) {
-    return targetClassStr;
-  }
-  return target.$tag_name || null;
+	// 4. No ancestor ID found -- use classes or tag name
+	if (targetClassStr) {
+		return targetClassStr;
+	}
+	return target.$tag_name || null;
 }
 
 // Convert clicks to sequence actions, deduplicating consecutive identical selectors
@@ -212,26 +210,26 @@ const actions = [];
 let lastSelector = null;
 
 for (const event of clicks) {
-  const props = event.properties;
-  const elements = props.$elements || [];
-  const selector = buildSelector(elements);
+	const props = event.properties;
+	const elements = props.$elements || [];
+	const selector = buildSelector(elements);
 
-  if (!selector) continue;
+	if (!selector) continue;
 
-  // Skip consecutive duplicate selectors (rage click noise)
-  if (selector === lastSelector) continue;
-  lastSelector = selector;
+	// Skip consecutive duplicate selectors (rage click noise)
+	if (selector === lastSelector) continue;
+	lastSelector = selector;
 
-  actions.push({ action: "click", selector });
+	actions.push({ action: 'click', selector });
 }
 
 const sequence = {
-  "my-funnel": {
-    description: "Converted from autocapture recording",
-    temperature: 9,
-    "chaos-range": [9, 10],
-    actions,
-  },
+	'my-funnel': {
+		description: 'Converted from autocapture recording',
+		temperature: 9,
+		'chaos-range': [9, 10],
+		actions
+	}
 };
 
 console.log(JSON.stringify(sequence, null, 2));
@@ -252,28 +250,28 @@ Here's a real `$mp_click` event from an Amazon browsing session (trimmed for cla
 
 ```json
 {
-  "event": "$mp_click",
-  "properties": {
-    "time": 1773769629,
-    "$el_tag_name": "img",
-    "$el_classes": [""],
-    "$current_url": "https://www.amazon.com/",
-    "$elements": [
-      { "$tag_name": "img", "$classes": [""], "$nth_child": 1 },
-      {
-        "$tag_name": "a",
-        "$attr-href": "/ROSSO-CAFFE.../dp/B0F7S9H5YJ/...",
-        "$classes": ["a-link-normal", "heroBlock0", "a-text-normal"]
-      },
-      { "$tag_name": "div", "$classes": ["a-section", "a-spacing-small"] },
-      {
-        "$tag_name": "div",
-        "$classes": ["a-cardui"],
-        "$id": "CardInstance4jMpZl1aYjl7SdRCWBqtyA"
-      },
-      { "$tag_name": "div", "$id": "desktop-btf-grid-1" }
-    ]
-  }
+	"event": "$mp_click",
+	"properties": {
+		"time": 1773769629,
+		"$el_tag_name": "img",
+		"$el_classes": [""],
+		"$current_url": "https://www.amazon.com/",
+		"$elements": [
+			{ "$tag_name": "img", "$classes": [""], "$nth_child": 1 },
+			{
+				"$tag_name": "a",
+				"$attr-href": "/ROSSO-CAFFE.../dp/B0F7S9H5YJ/...",
+				"$classes": ["a-link-normal", "heroBlock0", "a-text-normal"]
+			},
+			{ "$tag_name": "div", "$classes": ["a-section", "a-spacing-small"] },
+			{
+				"$tag_name": "div",
+				"$classes": ["a-cardui"],
+				"$id": "CardInstance4jMpZl1aYjl7SdRCWBqtyA"
+			},
+			{ "$tag_name": "div", "$id": "desktop-btf-grid-1" }
+		]
+	}
 }
 ```
 
@@ -371,58 +369,58 @@ Create three sequences:
 
 ```json
 {
-  "full-purchase-1": {
-    "description": "Complete the full purchase funnel",
-    "temperature": 9,
-    "chaos-range": [9, 10],
-    "actions": [
-      { "action": "click", "selector": "#browse-products" },
-      { "action": "click", "selector": "#add-to-cart" },
-      { "action": "click", "selector": "#checkout" },
-      { "action": "type", "selector": "#email", "text": "buyer@example.com" },
-      { "action": "click", "selector": "#complete-purchase" }
-    ]
-  },
-  "full-purchase-2": {
-    "description": "Complete the full purchase funnel (copy for weighting)",
-    "temperature": 9,
-    "chaos-range": [9, 10],
-    "actions": [
-      { "action": "click", "selector": "#browse-products" },
-      { "action": "click", "selector": "#add-to-cart" },
-      { "action": "click", "selector": "#checkout" },
-      { "action": "type", "selector": "#email", "text": "buyer@example.com" },
-      { "action": "click", "selector": "#complete-purchase" }
-    ]
-  },
-  "checkout-dropout": {
-    "description": "Gets to checkout but abandons",
-    "temperature": 9,
-    "chaos-range": [8, 10],
-    "actions": [
-      { "action": "click", "selector": "#browse-products" },
-      { "action": "click", "selector": "#add-to-cart" },
-      { "action": "click", "selector": "#checkout" }
-    ]
-  },
-  "browse-only": {
-    "description": "Browses products but never adds to cart",
-    "temperature": 7,
-    "chaos-range": [8, 10],
-    "actions": [
-      { "action": "click", "selector": "#browse-products" },
-      { "action": "click", "selector": ".product-card" }
-    ]
-  },
-  "browse-only-2": {
-    "description": "Browses products but never adds to cart (copy for weighting)",
-    "temperature": 7,
-    "chaos-range": [8, 10],
-    "actions": [
-      { "action": "click", "selector": "#browse-products" },
-      { "action": "click", "selector": ".product-card" }
-    ]
-  }
+	"full-purchase-1": {
+		"description": "Complete the full purchase funnel",
+		"temperature": 9,
+		"chaos-range": [9, 10],
+		"actions": [
+			{ "action": "click", "selector": "#browse-products" },
+			{ "action": "click", "selector": "#add-to-cart" },
+			{ "action": "click", "selector": "#checkout" },
+			{ "action": "type", "selector": "#email", "text": "buyer@example.com" },
+			{ "action": "click", "selector": "#complete-purchase" }
+		]
+	},
+	"full-purchase-2": {
+		"description": "Complete the full purchase funnel (copy for weighting)",
+		"temperature": 9,
+		"chaos-range": [9, 10],
+		"actions": [
+			{ "action": "click", "selector": "#browse-products" },
+			{ "action": "click", "selector": "#add-to-cart" },
+			{ "action": "click", "selector": "#checkout" },
+			{ "action": "type", "selector": "#email", "text": "buyer@example.com" },
+			{ "action": "click", "selector": "#complete-purchase" }
+		]
+	},
+	"checkout-dropout": {
+		"description": "Gets to checkout but abandons",
+		"temperature": 9,
+		"chaos-range": [8, 10],
+		"actions": [
+			{ "action": "click", "selector": "#browse-products" },
+			{ "action": "click", "selector": "#add-to-cart" },
+			{ "action": "click", "selector": "#checkout" }
+		]
+	},
+	"browse-only": {
+		"description": "Browses products but never adds to cart",
+		"temperature": 7,
+		"chaos-range": [8, 10],
+		"actions": [
+			{ "action": "click", "selector": "#browse-products" },
+			{ "action": "click", "selector": ".product-card" }
+		]
+	},
+	"browse-only-2": {
+		"description": "Browses products but never adds to cart (copy for weighting)",
+		"temperature": 7,
+		"chaos-range": [8, 10],
+		"actions": [
+			{ "action": "click", "selector": "#browse-products" },
+			{ "action": "click", "selector": ".product-card" }
+		]
+	}
 }
 ```
 
@@ -488,10 +486,10 @@ Use `expectsNavigation: true` on actions that trigger page navigation (links, fo
 
 ```json
 {
-  "action": "click",
-  "selector": "#next-page-link",
-  "expectsNavigation": true,
-  "navigationTimeout": 10000
+	"action": "click",
+	"selector": "#next-page-link",
+	"expectsNavigation": true,
+	"navigationTimeout": 10000
 }
 ```
 
@@ -564,36 +562,36 @@ A 7-step checkout flow with dynamic autocomplete and lazy-loaded modals:
 
 ```json
 {
-  "checkout": {
-    "description": "Multi-page checkout with optional upsell modal",
-    "temperature": 8,
-    "circuitBreaker": {
-      "maxFailures": 5,
-      "resetOnSuccess": true,
-      "mode": "skip"
-    },
-    "actions": [
-      { "action": "click", "selector": ".product" },
-      { "action": "click", "selector": "#add-to-cart" },
-      {
-        "action": "click",
-        "selector": "#upsell-modal-accept",
-        "requireActive": true
-      },
-      { "action": "click", "selector": "#checkout", "expectsNavigation": true },
-      {
-        "action": "type",
-        "selector": "#email",
-        "text": "customer@example.com"
-      },
-      {
-        "action": "click",
-        "selector": "#autocomplete-suggestion",
-        "requireActive": true
-      },
-      { "action": "click", "selector": "#complete-order" }
-    ]
-  }
+	"checkout": {
+		"description": "Multi-page checkout with optional upsell modal",
+		"temperature": 8,
+		"circuitBreaker": {
+			"maxFailures": 5,
+			"resetOnSuccess": true,
+			"mode": "skip"
+		},
+		"actions": [
+			{ "action": "click", "selector": ".product" },
+			{ "action": "click", "selector": "#add-to-cart" },
+			{
+				"action": "click",
+				"selector": "#upsell-modal-accept",
+				"requireActive": true
+			},
+			{ "action": "click", "selector": "#checkout", "expectsNavigation": true },
+			{
+				"action": "type",
+				"selector": "#email",
+				"text": "customer@example.com"
+			},
+			{
+				"action": "click",
+				"selector": "#autocomplete-suggestion",
+				"requireActive": true
+			},
+			{ "action": "click", "selector": "#complete-order" }
+		]
+	}
 }
 ```
 
@@ -635,31 +633,31 @@ To let some meeples roam freely without following any funnel, add a sequence wit
 
 ```json
 {
-  "checkout-funnel": {
-    "description": "Complete checkout flow",
-    "temperature": 9,
-    "chaos-range": [9, 10],
-    "actions": [
-      { "action": "click", "selector": "#add-to-cart" },
-      { "action": "click", "selector": "#checkout" },
-      { "action": "click", "selector": "#purchase" }
-    ]
-  },
-  "explorer": {
-    "description": "Free exploration - meeple wanders the site randomly",
-    "temperature": 0,
-    "chaos-range": [1, 1],
-    "actions": [
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" },
-      { "action": "click", "selector": "body" }
-    ]
-  }
+	"checkout-funnel": {
+		"description": "Complete checkout flow",
+		"temperature": 9,
+		"chaos-range": [9, 10],
+		"actions": [
+			{ "action": "click", "selector": "#add-to-cart" },
+			{ "action": "click", "selector": "#checkout" },
+			{ "action": "click", "selector": "#purchase" }
+		]
+	},
+	"explorer": {
+		"description": "Free exploration - meeple wanders the site randomly",
+		"temperature": 0,
+		"chaos-range": [1, 1],
+		"actions": [
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" },
+			{ "action": "click", "selector": "body" }
+		]
+	}
 }
 ```
 
@@ -731,52 +729,52 @@ Open the meeple UI at `https://meeple.mixpanel.org`, paste your sequence JSON in
 
 ```json
 {
-  "results": [
-    {
-      "actions": [
-        {
-          "action": "click",
-          "selector": "#add-to-cart",
-          "success": true,
-          "duration": 245,
-          "timestamp": 1647891234567,
-          "page_url": "https://example.com/products"
-        },
-        {
-          "action": "click",
-          "selector": "#missing-element",
-          "success": false,
-          "error": "Element not found: #missing-element",
-          "reason": "selector_not_found",
-          "duration": 5234,
-          "timestamp": 1647891239801,
-          "page_url": "https://example.com/cart"
-        },
-        {
-          "action": "click",
-          "selector": "#disabled-button",
-          "success": true,
-          "skipped": true,
-          "duration": 123,
-          "timestamp": 1647891245035,
-          "page_url": "https://example.com/cart"
-        }
-      ],
-      "duration": 12,
-      "persona": "researcher",
-      "sequence": "my-funnel",
-      "success": true,
-      "circuit_breaker_triggered": false,
-      "failed_actions": [
-        {
-          "action": "click",
-          "selector": "#missing-element",
-          "reason": "selector_not_found",
-          "page_url": "https://example.com/cart"
-        }
-      ]
-    }
-  ]
+	"results": [
+		{
+			"actions": [
+				{
+					"action": "click",
+					"selector": "#add-to-cart",
+					"success": true,
+					"duration": 245,
+					"timestamp": 1647891234567,
+					"page_url": "https://example.com/products"
+				},
+				{
+					"action": "click",
+					"selector": "#missing-element",
+					"success": false,
+					"error": "Element not found: #missing-element",
+					"reason": "selector_not_found",
+					"duration": 5234,
+					"timestamp": 1647891239801,
+					"page_url": "https://example.com/cart"
+				},
+				{
+					"action": "click",
+					"selector": "#disabled-button",
+					"success": true,
+					"skipped": true,
+					"duration": 123,
+					"timestamp": 1647891245035,
+					"page_url": "https://example.com/cart"
+				}
+			],
+			"duration": 12,
+			"persona": "researcher",
+			"sequence": "my-funnel",
+			"success": true,
+			"circuit_breaker_triggered": false,
+			"failed_actions": [
+				{
+					"action": "click",
+					"selector": "#missing-element",
+					"reason": "selector_not_found",
+					"page_url": "https://example.com/cart"
+				}
+			]
+		}
+	]
 }
 ```
 

--- a/tests/meeple.test.js
+++ b/tests/meeple.test.js
@@ -5,376 +5,341 @@
  * Tests individual modules with minimal mocking using real browser instances
  */
 
+import { getRandomTimestampWithinLast5Days, extractTopLevelDomain } from '../meeple/analytics.js';
+import { selectPersona, getContextAwareAction, generatePersonaActionSequence } from '../meeple/personas.js';
 import {
-  getRandomTimestampWithinLast5Days,
-  extractTopLevelDomain,
-} from "../meeple/analytics.js";
+	generateHumanizedPath,
+	bezierPoint,
+	exploratoryClick,
+	wait,
+	coinFlip,
+	moveMouse,
+	clickStuff,
+	intelligentScroll,
+	naturalMouseMovement,
+	hoverOverElements
+} from '../meeple/interactions.js';
 import {
-  selectPersona,
-  getContextAwareAction,
-  generatePersonaActionSequence,
-} from "../meeple/personas.js";
-import {
-  generateHumanizedPath,
-  bezierPoint,
-  exploratoryClick,
-  wait,
-  coinFlip,
-  moveMouse,
-  clickStuff,
-  intelligentScroll,
-  naturalMouseMovement,
-  hoverOverElements,
-} from "../meeple/interactions.js";
-import {
-  interactWithForms,
-  fillTextInput,
-  fillRadioGroup,
-  toggleCheckbox,
-  fillSelectDropdown,
-  fillFormElement,
-} from "../meeple/forms.js";
-import { navigateBack, navigateForward } from "../meeple/navigation.js";
-import {
-  identifyHotZones,
-  rectsOverlap,
-} from "../meeple/hotzones.js";
-import {
-  navigateToUrl,
-  getPageInfo,
-} from "../meeple/browser.js";
-import {
-  randomBetween,
-  clamp,
-  distance,
-  shuffle,
-} from "../meeple/utils.js";
-import {
-  ensureCSPRelaxed,
-  ensurePageSetup,
-} from "../meeple/security.js";
-import {
-  executeSequence,
-  validateSequence,
-  validateSequences,
-} from "../meeple/sequences.js";
+	interactWithForms,
+	fillTextInput,
+	fillRadioGroup,
+	toggleCheckbox,
+	fillSelectDropdown,
+	fillFormElement
+} from '../meeple/forms.js';
+import { navigateBack, navigateForward } from '../meeple/navigation.js';
+import { identifyHotZones, rectsOverlap } from '../meeple/hotzones.js';
+import { navigateToUrl, getPageInfo } from '../meeple/browser.js';
+import { randomBetween, clamp, distance, shuffle } from '../meeple/utils.js';
+import { ensureCSPRelaxed, ensurePageSetup } from '../meeple/security.js';
+import { executeSequence, validateSequence, validateSequences } from '../meeple/sequences.js';
 
 // Set test environment
-process.env.NODE_ENV = "test";
-process.env.MIXPANEL_TOKEN = "test-token-for-testing";
+process.env.NODE_ENV = 'test';
+process.env.MIXPANEL_TOKEN = 'test-token-for-testing';
 
-describe("Meeple Modules - Unit Tests", () => {
-  let testPage;
+describe('Meeple Modules - Unit Tests', () => {
+	let testPage;
 
-  beforeEach(async () => {
-    testPage = await browser.newPage();
-    await testPage.setViewport({ width: 1280, height: 800 });
+	beforeEach(async () => {
+		testPage = await browser.newPage();
+		await testPage.setViewport({ width: 1280, height: 800 });
 
-    // Navigate to the real aktunes.com website
-    await testPage.goto("https://aktunes.com", {
-      waitUntil: "networkidle2",
-      timeout: 15000,
-    });
+		// Navigate to the real aktunes.com website
+		await testPage.goto('https://aktunes.com', {
+			waitUntil: 'networkidle2',
+			timeout: 15000
+		});
 
-    // Add mouse tracking for movement tests
-    await testPage.evaluate(() => {
-      window.mouseX = 0;
-      window.mouseY = 0;
-      document.addEventListener("mousemove", (e) => {
-        window.mouseX = e.clientX;
-        window.mouseY = e.clientY;
-      });
-    });
-  }, 20000);
+		// Add mouse tracking for movement tests
+		await testPage.evaluate(() => {
+			window.mouseX = 0;
+			window.mouseY = 0;
+			document.addEventListener('mousemove', e => {
+				window.mouseX = e.clientX;
+				window.mouseY = e.clientY;
+			});
+		});
+	}, 20000);
 
-  afterEach(async () => {
-    if (testPage && !testPage.isClosed()) {
-      await testPage.close();
-    }
-  });
+	afterEach(async () => {
+		if (testPage && !testPage.isClosed()) {
+			await testPage.close();
+		}
+	});
 
-  describe("Analytics Module", () => {
-    test("getRandomTimestampWithinLast5Days returns valid timestamp", () => {
-      const timestamp = getRandomTimestampWithinLast5Days();
-      const now = Date.now();
-      const fiveDaysAgo = now - 5 * 24 * 60 * 60 * 1000;
+	describe('Analytics Module', () => {
+		test('getRandomTimestampWithinLast5Days returns valid timestamp', () => {
+			const timestamp = getRandomTimestampWithinLast5Days();
+			const now = Date.now();
+			const fiveDaysAgo = now - 5 * 24 * 60 * 60 * 1000;
 
-      expect(timestamp).toBeGreaterThanOrEqual(fiveDaysAgo);
-      expect(timestamp).toBeLessThanOrEqual(now);
-      expect(typeof timestamp).toBe("number");
-    });
+			expect(timestamp).toBeGreaterThanOrEqual(fiveDaysAgo);
+			expect(timestamp).toBeLessThanOrEqual(now);
+			expect(typeof timestamp).toBe('number');
+		});
 
-    test("extractTopLevelDomain extracts domain correctly", () => {
-      expect(extractTopLevelDomain("example.com")).toBe("example.com");
-      expect(extractTopLevelDomain("sub.example.com")).toBe("example.com");
-      expect(extractTopLevelDomain("test.co.uk")).toBe("test.co.uk");
-      expect(extractTopLevelDomain("localhost")).toBe("localhost");
-      expect(extractTopLevelDomain("")).toBe("[empty-hostname]");
-    });
-  });
+		test('extractTopLevelDomain extracts domain correctly', () => {
+			expect(extractTopLevelDomain('example.com')).toBe('example.com');
+			expect(extractTopLevelDomain('sub.example.com')).toBe('example.com');
+			expect(extractTopLevelDomain('test.co.uk')).toBe('test.co.uk');
+			expect(extractTopLevelDomain('localhost')).toBe('localhost');
+			expect(extractTopLevelDomain('')).toBe('[empty-hostname]');
+		});
+	});
 
-  describe("Utils Module", () => {
-    test("randomBetween generates numbers in range", () => {
-      for (let i = 0; i < 10; i++) {
-        const result = randomBetween(5, 15);
-        expect(result).toBeGreaterThanOrEqual(5);
-        expect(result).toBeLessThanOrEqual(15);
-      }
-    });
+	describe('Utils Module', () => {
+		test('randomBetween generates numbers in range', () => {
+			for (let i = 0; i < 10; i++) {
+				const result = randomBetween(5, 15);
+				expect(result).toBeGreaterThanOrEqual(5);
+				expect(result).toBeLessThanOrEqual(15);
+			}
+		});
 
-    test("clamp constrains values to range", () => {
-      expect(clamp(5, 0, 10)).toBe(5);
-      expect(clamp(-5, 0, 10)).toBe(0);
-      expect(clamp(15, 0, 10)).toBe(10);
-    });
+		test('clamp constrains values to range', () => {
+			expect(clamp(5, 0, 10)).toBe(5);
+			expect(clamp(-5, 0, 10)).toBe(0);
+			expect(clamp(15, 0, 10)).toBe(10);
+		});
 
-    test("distance calculates Euclidean distance", () => {
-      expect(distance(0, 0, 3, 4)).toBe(5);
-      expect(distance(0, 0, 0, 0)).toBe(0);
-    });
+		test('distance calculates Euclidean distance', () => {
+			expect(distance(0, 0, 3, 4)).toBe(5);
+			expect(distance(0, 0, 0, 0)).toBe(0);
+		});
 
-    test("shuffle randomizes array", () => {
-      const original = [1, 2, 3, 4, 5];
-      const shuffled = shuffle([...original]);
-      expect(shuffled).toHaveLength(5);
-      expect(shuffled).toEqual(expect.arrayContaining(original));
-    });
-  });
+		test('shuffle randomizes array', () => {
+			const original = [1, 2, 3, 4, 5];
+			const shuffled = shuffle([...original]);
+			expect(shuffled).toHaveLength(5);
+			expect(shuffled).toEqual(expect.arrayContaining(original));
+		});
+	});
 
-  describe("Personas Module", () => {
-    test("selectPersona returns valid persona", () => {
-      const persona = selectPersona();
-      const validPersonas = [
-        "powerUser",
-        "taskFocused",
-        "digitalNative",
-        "shopper",
-        "comparison",
-        "conversionOptimized",
-        "reader",
-        "skimmer",
-        "bingeWatcher",
-        "explorer",
-        "discoverer",
-        "curiosityDriven",
-        "mobileHabits",
-        "mobileFirst",
-        "tabletUser",
-        "decisive",
-        "minimalist",
-        "researcher",
-        "methodical",
-        "analytical",
-        "accessibilityUser",
-        "keyboardNavigator",
-        "genZ",
-        "millennial",
-        "genX",
-        "boomer",
-        "anxiousUser",
-        "confidentUser",
-        "cautiousUser",
-        "international",
-        "rtlUser",
-        "minMaxer",
-        "rolePlayer",
-        "murderHobo",
-        "ruleSlawyer",
-      ];
-      expect(validPersonas).toContain(persona);
-    });
+	describe('Personas Module', () => {
+		test('selectPersona returns valid persona', () => {
+			const persona = selectPersona();
+			const validPersonas = [
+				'powerUser',
+				'taskFocused',
+				'digitalNative',
+				'shopper',
+				'comparison',
+				'conversionOptimized',
+				'reader',
+				'skimmer',
+				'bingeWatcher',
+				'explorer',
+				'discoverer',
+				'curiosityDriven',
+				'mobileHabits',
+				'mobileFirst',
+				'tabletUser',
+				'decisive',
+				'minimalist',
+				'researcher',
+				'methodical',
+				'analytical',
+				'accessibilityUser',
+				'keyboardNavigator',
+				'genZ',
+				'millennial',
+				'genX',
+				'boomer',
+				'anxiousUser',
+				'confidentUser',
+				'cautiousUser',
+				'international',
+				'rtlUser',
+				'minMaxer',
+				'rolePlayer',
+				'murderHobo',
+				'ruleSlawyer'
+			];
+			expect(validPersonas).toContain(persona);
+		});
 
-    test("generatePersonaActionSequence creates valid sequence", () => {
-      const sequence = generatePersonaActionSequence("powerUser", 5);
-      expect(sequence).toHaveLength(5);
-      expect(Array.isArray(sequence)).toBe(true);
+		test('generatePersonaActionSequence creates valid sequence', () => {
+			const sequence = generatePersonaActionSequence('powerUser', 5);
+			expect(sequence).toHaveLength(5);
+			expect(Array.isArray(sequence)).toBe(true);
 
-      // Should contain valid action types
-      const validActions = [
-        "click",
-        "scroll",
-        "mouse",
-        "hover",
-        "wait",
-        "form",
-        "back",
-        "forward",
-        "exploratoryClick",
-        "rageClick",
-      ];
-      sequence.forEach((action) => {
-        expect(validActions).toContain(action);
-      });
-    });
+			// Should contain valid action types
+			const validActions = [
+				'click',
+				'scroll',
+				'mouse',
+				'hover',
+				'wait',
+				'form',
+				'back',
+				'forward',
+				'exploratoryClick',
+				'rageClick'
+			];
+			sequence.forEach(action => {
+				expect(validActions).toContain(action);
+			});
+		});
 
-    test("getContextAwareAction adapts actions based on history", () => {
-      const actionHistory = ["click", "click", "click"];
-      const adaptedAction = getContextAwareAction(actionHistory, "click");
+		test('getContextAwareAction adapts actions based on history', () => {
+			const actionHistory = ['click', 'click', 'click'];
+			const adaptedAction = getContextAwareAction(actionHistory, 'click');
 
-      // After 3 consecutive clicks, should adapt to something else
-      expect(adaptedAction).not.toBe("click");
-    });
-  });
+			// After 3 consecutive clicks, should adapt to something else
+			expect(adaptedAction).not.toBe('click');
+		});
+	});
 
-  describe("Interactions Module", () => {
-    test("generateHumanizedPath creates realistic mouse path", () => {
-      const path = generateHumanizedPath(0, 0, 100, 100);
+	describe('Interactions Module', () => {
+		test('generateHumanizedPath creates realistic mouse path', () => {
+			const path = generateHumanizedPath(0, 0, 100, 100);
 
-      expect(Array.isArray(path)).toBe(true);
-      expect(path.length).toBeGreaterThan(0);
-      expect(path[0]).toEqual(
-        expect.objectContaining({
-          x: expect.any(Number),
-          y: expect.any(Number),
-          timing: expect.any(Number),
-        }),
-      );
-      expect(path[path.length - 1].x).toBeCloseTo(100, -1);
-      expect(path[path.length - 1].y).toBeCloseTo(100, -1);
-    });
+			expect(Array.isArray(path)).toBe(true);
+			expect(path.length).toBeGreaterThan(0);
+			expect(path[0]).toEqual(
+				expect.objectContaining({
+					x: expect.any(Number),
+					y: expect.any(Number),
+					timing: expect.any(Number)
+				})
+			);
+			expect(path[path.length - 1].x).toBeCloseTo(100, -1);
+			expect(path[path.length - 1].y).toBeCloseTo(100, -1);
+		});
 
-    test("bezierPoint calculates correct curve point", () => {
-      const point = bezierPoint(
-        { x: 0, y: 0 },
-        { x: 25, y: 50 },
-        { x: 75, y: 50 },
-        { x: 100, y: 0 },
-        0.5,
-      );
-      expect(point.x).toBeCloseTo(50, 1);
-      expect(point.y).toBeCloseTo(37.5, 1);
-    });
+		test('bezierPoint calculates correct curve point', () => {
+			const point = bezierPoint({ x: 0, y: 0 }, { x: 25, y: 50 }, { x: 75, y: 50 }, { x: 100, y: 0 }, 0.5);
+			expect(point.x).toBeCloseTo(50, 1);
+			expect(point.y).toBeCloseTo(37.5, 1);
+		});
 
-    test("coinFlip returns boolean", () => {
-      const result = coinFlip();
-      expect(typeof result).toBe("boolean");
-    });
+		test('coinFlip returns boolean', () => {
+			const result = coinFlip();
+			expect(typeof result).toBe('boolean');
+		});
 
-    test("wait function resolves after delay", async () => {
-      const start = Date.now();
-      await wait();
-      const elapsed = Date.now() - start;
-      expect(elapsed).toBeGreaterThanOrEqual(90); // Allow some timing variance
-    });
+		test('wait function resolves after delay', async () => {
+			const start = Date.now();
+			await wait();
+			const elapsed = Date.now() - start;
+			expect(elapsed).toBeGreaterThanOrEqual(90); // Allow some timing variance
+		});
 
-    test("exploratoryClick finds and clicks elements", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('exploratoryClick finds and clicks elements', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      await exploratoryClick(testPage, consoleSpy);
+			await exploratoryClick(testPage, consoleSpy);
 
-      // Should have logged something about the click attempt
-      expect(logMessages.length).toBeGreaterThan(0);
-    }, 10000);
+			// Should have logged something about the click attempt
+			expect(logMessages.length).toBeGreaterThan(0);
+		}, 10000);
 
-    test("moveMouse moves cursor realistically", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('moveMouse moves cursor realistically', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      await moveMouse(testPage, 10, 10, 100, 100, 50, 50, consoleSpy);
+			await moveMouse(testPage, 10, 10, 100, 100, 50, 50, consoleSpy);
 
-      // Check final mouse position (allow for some variance due to humanized movement)
-      const finalPosition = await testPage.evaluate(() => ({
-        x: window.mouseX,
-        y: window.mouseY,
-      }));
-      expect(finalPosition.x).toBeCloseTo(100, -1); // Allow ~5 pixel tolerance
-      expect(finalPosition.y).toBeCloseTo(100, -1);
-    }, 10000);
-  });
+			// Check final mouse position (allow for some variance due to humanized movement)
+			const finalPosition = await testPage.evaluate(() => ({
+				x: window.mouseX,
+				y: window.mouseY
+			}));
+			expect(finalPosition.x).toBeCloseTo(100, -1); // Allow ~5 pixel tolerance
+			expect(finalPosition.y).toBeCloseTo(100, -1);
+		}, 10000);
+	});
 
-  describe("Hot Zones Module", () => {
-    test("rectsOverlap detects rectangle overlap correctly", () => {
-      const rect1 = { left: 0, top: 0, right: 50, bottom: 50 };
-      const rect2 = { left: 25, top: 25, right: 75, bottom: 75 };
-      const rect3 = { left: 100, top: 100, right: 150, bottom: 150 };
+	describe('Hot Zones Module', () => {
+		test('rectsOverlap detects rectangle overlap correctly', () => {
+			const rect1 = { left: 0, top: 0, right: 50, bottom: 50 };
+			const rect2 = { left: 25, top: 25, right: 75, bottom: 75 };
+			const rect3 = { left: 100, top: 100, right: 150, bottom: 150 };
 
-      expect(rectsOverlap(rect1, rect2)).toBe(true);
-      expect(rectsOverlap(rect1, rect3)).toBe(false);
-    });
+			expect(rectsOverlap(rect1, rect2)).toBe(true);
+			expect(rectsOverlap(rect1, rect3)).toBe(false);
+		});
 
-    test("identifyHotZones finds interactive elements", async () => {
-      const hotZones = await identifyHotZones(testPage);
+		test('identifyHotZones finds interactive elements', async () => {
+			const hotZones = await identifyHotZones(testPage);
 
-      expect(Array.isArray(hotZones)).toBe(true);
-      expect(hotZones.length).toBeGreaterThan(0);
+			expect(Array.isArray(hotZones)).toBe(true);
+			expect(hotZones.length).toBeGreaterThan(0);
 
-      console.log(
-        "Found hot zones:",
-        hotZones.map((z) => z.tagName),
-      );
-    }, 15000);
-  });
+			console.log(
+				'Found hot zones:',
+				hotZones.map(z => z.tagName)
+			);
+		}, 15000);
+	});
 
-  describe("Browser Module", () => {
-    test("navigateToUrl navigates to URL", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+	describe('Browser Module', () => {
+		test('navigateToUrl navigates to URL', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      // Navigate to a section of the aktunes site
-      await navigateToUrl(testPage, "https://aktunes.com#ak", consoleSpy);
+			// Navigate to a section of the aktunes site
+			await navigateToUrl(testPage, 'https://aktunes.com#ak', consoleSpy);
 
-      const url = testPage.url();
-      expect(url).toContain("aktunes.com");
-      expect(logMessages.length).toBeGreaterThan(0);
-    }, 10000);
+			const url = testPage.url();
+			expect(url).toContain('aktunes.com');
+			expect(logMessages.length).toBeGreaterThan(0);
+		}, 10000);
 
-    test("getPageInfo extracts page information", async () => {
-      const pageInfo = await getPageInfo(testPage);
+		test('getPageInfo extracts page information', async () => {
+			const pageInfo = await getPageInfo(testPage);
 
-      expect(pageInfo).toHaveProperty("title");
-      expect(pageInfo).toHaveProperty("url");
-      expect(pageInfo.title).toBe("AK | the aesthetic of maximalism");
-      expect(pageInfo.url).toContain("aktunes.com");
-    }, 10000);
-  });
+			expect(pageInfo).toHaveProperty('title');
+			expect(pageInfo).toHaveProperty('url');
+			expect(pageInfo.title).toBe('AK | the aesthetic of maximalism');
+			expect(pageInfo.url).toContain('aktunes.com');
+		}, 10000);
+	});
 
-  describe("Security Module", () => {
-    test("ensureCSPRelaxed relaxes CSP without errors", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+	describe('Security Module', () => {
+		test('ensureCSPRelaxed relaxes CSP without errors', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      await expect(
-        ensureCSPRelaxed(testPage, consoleSpy),
-      ).resolves.not.toThrow();
-    }, 10000);
+			await expect(ensureCSPRelaxed(testPage, consoleSpy)).resolves.not.toThrow();
+		}, 10000);
 
-    test("ensurePageSetup runs without errors", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('ensurePageSetup runs without errors', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      await expect(
-        ensurePageSetup(testPage, "testUser", false, {}, consoleSpy),
-      ).resolves.not.toThrow();
-    }, 10000);
-  });
+			await expect(ensurePageSetup(testPage, 'testUser', false, {}, consoleSpy)).resolves.not.toThrow();
+		}, 10000);
+	});
 
-  describe("Forms Module", () => {
-    test("interactWithForms finds and interacts with forms", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+	describe('Forms Module', () => {
+		test('interactWithForms finds and interacts with forms', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      // First navigate to the contact section where the form is
-      await testPage.click('a[href="#contact"]');
-      await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait for any animations
+			// First navigate to the contact section where the form is
+			await testPage.click('a[href="#contact"]');
+			await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for any animations
 
-      await interactWithForms(testPage, consoleSpy);
+			await interactWithForms(testPage, consoleSpy);
 
-      // Should have attempted form interaction on the contact form
-      expect(logMessages.length).toBeGreaterThan(0);
+			// Should have attempted form interaction on the contact form
+			expect(logMessages.length).toBeGreaterThan(0);
 
-      // Check if form fields exist on the page
-      const nameField = await testPage.$('input[name="name"]');
-      const emailField = await testPage.$('input[name="email"]');
-      const commentsField = await testPage.$('textarea[name="comments"]');
+			// Check if form fields exist on the page
+			const nameField = await testPage.$('input[name="name"]');
+			const emailField = await testPage.$('input[name="email"]');
+			const commentsField = await testPage.$('textarea[name="comments"]');
 
-      expect(nameField).toBeTruthy();
-      expect(emailField).toBeTruthy();
-      expect(commentsField).toBeTruthy();
-    }, 15000);
+			expect(nameField).toBeTruthy();
+			expect(emailField).toBeTruthy();
+			expect(commentsField).toBeTruthy();
+		}, 15000);
 
-    test("interactWithForms handles new form types (radios, checkboxes)", async () => {
-      await testPage.setContent(`
+		test('interactWithForms handles new form types (radios, checkboxes)', async () => {
+			await testPage.setContent(`
         <html>
           <body>
             <input type="checkbox" id="agree" style="width: 20px; height: 20px;">
@@ -387,23 +352,23 @@ describe("Meeple Modules - Unit Tests", () => {
         </html>
       `);
 
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      await interactWithForms(testPage, consoleSpy);
+			await interactWithForms(testPage, consoleSpy);
 
-      // Should have found and interacted with at least one form element
-      expect(logMessages.length).toBeGreaterThan(0);
+			// Should have found and interacted with at least one form element
+			expect(logMessages.length).toBeGreaterThan(0);
 
-      // Should mention finding form elements
-      const foundElements = logMessages.some((m) => m.includes("form element"));
-      expect(foundElements).toBe(true);
-    }, 10000);
+			// Should mention finding form elements
+			const foundElements = logMessages.some(m => m.includes('form element'));
+			expect(foundElements).toBe(true);
+		}, 10000);
 
-    describe("Enhanced Form Utilities", () => {
-      beforeEach(async () => {
-        // Create a comprehensive test page with all form element types
-        await testPage.setContent(`
+		describe('Enhanced Form Utilities', () => {
+			beforeEach(async () => {
+				// Create a comprehensive test page with all form element types
+				await testPage.setContent(`
           <html>
             <head><title>Form Test Page</title></head>
             <body>
@@ -423,235 +388,194 @@ describe("Meeple Modules - Unit Tests", () => {
             </body>
           </html>
         `);
-      });
+			});
 
-      test("fillTextInput types text into input field", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
-        const element = await testPage.$("#textInput");
+			test('fillTextInput types text into input field', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
+				const element = await testPage.$('#textInput');
 
-        const result = await fillTextInput(
-          testPage,
-          element,
-          "Test Text",
-          consoleSpy,
-        );
+				const result = await fillTextInput(testPage, element, 'Test Text', consoleSpy);
 
-        expect(result).toBe(true);
-        const value = await testPage.$eval("#textInput", (el) => el.value);
-        expect(value).toBe("Test Text");
-      }, 10000);
+				expect(result).toBe(true);
+				const value = await testPage.$eval('#textInput', el => el.value);
+				expect(value).toBe('Test Text');
+			}, 10000);
 
-      test("fillTextInput uses test data when no text provided", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
-        const element = await testPage.$("#textInput");
+			test('fillTextInput uses test data when no text provided', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
+				const element = await testPage.$('#textInput');
 
-        const result = await fillTextInput(testPage, element, null, consoleSpy);
+				const result = await fillTextInput(testPage, element, null, consoleSpy);
 
-        expect(result).toBe(true);
-        const value = await testPage.$eval("#textInput", (el) => el.value);
-        expect(value.length).toBeGreaterThan(0); // Should have typed something
-      }, 10000);
+				expect(result).toBe(true);
+				const value = await testPage.$eval('#textInput', el => el.value);
+				expect(value.length).toBeGreaterThan(0); // Should have typed something
+			}, 10000);
 
-      test("fillSelectDropdown selects option from dropdown", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
-        const element = await testPage.$("#dropdown");
+			test('fillSelectDropdown selects option from dropdown', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
+				const element = await testPage.$('#dropdown');
 
-        const result = await fillSelectDropdown(
-          testPage,
-          element,
-          "opt2",
-          consoleSpy,
-        );
+				const result = await fillSelectDropdown(testPage, element, 'opt2', consoleSpy);
 
-        expect(result).toBe(true);
-        const value = await testPage.$eval("#dropdown", (el) => el.value);
-        expect(value).toBe("opt2");
-      }, 10000);
+				expect(result).toBe(true);
+				const value = await testPage.$eval('#dropdown', el => el.value);
+				expect(value).toBe('opt2');
+			}, 10000);
 
-      test("fillSelectDropdown picks random option when no value provided", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
-        const element = await testPage.$("#dropdown");
+			test('fillSelectDropdown picks random option when no value provided', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
+				const element = await testPage.$('#dropdown');
 
-        const result = await fillSelectDropdown(
-          testPage,
-          element,
-          null,
-          consoleSpy,
-        );
+				const result = await fillSelectDropdown(testPage, element, null, consoleSpy);
 
-        expect(result).toBe(true);
-        const value = await testPage.$eval("#dropdown", (el) => el.value);
-        expect(["opt1", "opt2", "opt3"]).toContain(value);
-      }, 10000);
+				expect(result).toBe(true);
+				const value = await testPage.$eval('#dropdown', el => el.value);
+				expect(['opt1', 'opt2', 'opt3']).toContain(value);
+			}, 10000);
 
-      test("toggleCheckbox clicks checkbox element", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
-        const element = await testPage.$("#checkbox");
+			test('toggleCheckbox clicks checkbox element', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
+				const element = await testPage.$('#checkbox');
 
-        const result = await toggleCheckbox(testPage, element, consoleSpy);
+				const result = await toggleCheckbox(testPage, element, consoleSpy);
 
-        expect(result).toBe(true);
-        const checked = await testPage.$eval("#checkbox", (el) => el.checked);
-        expect(checked).toBe(true);
-      }, 10000);
+				expect(result).toBe(true);
+				const checked = await testPage.$eval('#checkbox', el => el.checked);
+				expect(checked).toBe(true);
+			}, 10000);
 
-      test("fillRadioGroup clicks radio buttons multiple times", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
-        const element = await testPage.$("#radioGroup");
+			test('fillRadioGroup clicks radio buttons multiple times', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
+				const element = await testPage.$('#radioGroup');
 
-        const result = await fillRadioGroup(testPage, element, 3, consoleSpy);
+				const result = await fillRadioGroup(testPage, element, 3, consoleSpy);
 
-        expect(result).toBe(true);
-        // Should have clicked radios (at least one should be checked)
-        const anyChecked = await testPage.evaluate(() => {
-          const radios = document.querySelectorAll(
-            '#radioGroup input[type="radio"]',
-          );
-          return Array.from(radios).some((r) => r.checked);
-        });
-        expect(anyChecked).toBe(true);
-      }, 10000);
+				expect(result).toBe(true);
+				// Should have clicked radios (at least one should be checked)
+				const anyChecked = await testPage.evaluate(() => {
+					const radios = document.querySelectorAll('#radioGroup input[type="radio"]');
+					return Array.from(radios).some(r => r.checked);
+				});
+				expect(anyChecked).toBe(true);
+			}, 10000);
 
-      test("fillFormElement routes to correct handler based on element type", async () => {
-        const logMessages = [];
-        const consoleSpy = (message) => logMessages.push(message);
+			test('fillFormElement routes to correct handler based on element type', async () => {
+				const logMessages = [];
+				const consoleSpy = message => logMessages.push(message);
 
-        // Test text input
-        const textElement = await testPage.$("#textInput");
-        const textResult = await fillFormElement(
-          testPage,
-          textElement,
-          { text: "Auto Text" },
-          consoleSpy,
-        );
-        expect(textResult).toBe(true);
+				// Test text input
+				const textElement = await testPage.$('#textInput');
+				const textResult = await fillFormElement(testPage, textElement, { text: 'Auto Text' }, consoleSpy);
+				expect(textResult).toBe(true);
 
-        // Test select
-        const selectElement = await testPage.$("#dropdown");
-        const selectResult = await fillFormElement(
-          testPage,
-          selectElement,
-          { value: "opt3" },
-          consoleSpy,
-        );
-        expect(selectResult).toBe(true);
+				// Test select
+				const selectElement = await testPage.$('#dropdown');
+				const selectResult = await fillFormElement(testPage, selectElement, { value: 'opt3' }, consoleSpy);
+				expect(selectResult).toBe(true);
 
-        // Test checkbox
-        const checkboxElement = await testPage.$("#checkbox");
-        const checkboxResult = await fillFormElement(
-          testPage,
-          checkboxElement,
-          {},
-          consoleSpy,
-        );
-        expect(checkboxResult).toBe(true);
+				// Test checkbox
+				const checkboxElement = await testPage.$('#checkbox');
+				const checkboxResult = await fillFormElement(testPage, checkboxElement, {}, consoleSpy);
+				expect(checkboxResult).toBe(true);
 
-        // Verify all were filled correctly
-        const textValue = await testPage.$eval("#textInput", (el) => el.value);
-        const selectValue = await testPage.$eval("#dropdown", (el) => el.value);
-        const checkboxValue = await testPage.$eval(
-          "#checkbox",
-          (el) => el.checked,
-        );
+				// Verify all were filled correctly
+				const textValue = await testPage.$eval('#textInput', el => el.value);
+				const selectValue = await testPage.$eval('#dropdown', el => el.value);
+				const checkboxValue = await testPage.$eval('#checkbox', el => el.checked);
 
-        expect(textValue).toBe("Auto Text");
-        expect(selectValue).toBe("opt3");
-        expect(checkboxValue).toBe(true);
-      }, 15000);
-    });
-  });
+				expect(textValue).toBe('Auto Text');
+				expect(selectValue).toBe('opt3');
+				expect(checkboxValue).toBe(true);
+			}, 15000);
+		});
+	});
 
-  describe("Navigation Module", () => {
-    test("navigateBack attempts to go back", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+	describe('Navigation Module', () => {
+		test('navigateBack attempts to go back', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const result = await navigateBack(testPage, consoleSpy);
+			const result = await navigateBack(testPage, consoleSpy);
 
-      expect(typeof result).toBe("boolean");
-      // Navigation functions may not always generate logs if no action is taken
-      expect(logMessages.length).toBeGreaterThanOrEqual(0);
-    }, 10000);
+			expect(typeof result).toBe('boolean');
+			// Navigation functions may not always generate logs if no action is taken
+			expect(logMessages.length).toBeGreaterThanOrEqual(0);
+		}, 10000);
 
-    test("navigateForward attempts to go forward", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('navigateForward attempts to go forward', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const result = await navigateForward(testPage, consoleSpy);
+			const result = await navigateForward(testPage, consoleSpy);
 
-      expect(typeof result).toBe("boolean");
-      // Navigation functions may not always generate logs if no action is taken
-      expect(logMessages.length).toBeGreaterThanOrEqual(0);
-    }, 10000);
-  });
+			expect(typeof result).toBe('boolean');
+			// Navigation functions may not always generate logs if no action is taken
+			expect(logMessages.length).toBeGreaterThanOrEqual(0);
+		}, 10000);
+	});
 
-  describe("Integration Tests", () => {
-    test("clickStuff uses hot zones for intelligent clicking", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
-      const hotZones = await identifyHotZones(testPage);
+	describe('Integration Tests', () => {
+		test('clickStuff uses hot zones for intelligent clicking', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
+			const hotZones = await identifyHotZones(testPage);
 
-      await clickStuff(testPage, hotZones, consoleSpy);
+			await clickStuff(testPage, hotZones, consoleSpy);
 
-      expect(logMessages.length).toBeGreaterThan(0);
-      expect(hotZones.length).toBeGreaterThan(0);
+			expect(logMessages.length).toBeGreaterThan(0);
+			expect(hotZones.length).toBeGreaterThan(0);
 
-      // Verify hot zones found actual interactive elements from aktunes.com
-      const elementTypes = hotZones.map((zone) => zone.tagName).filter(Boolean);
-      expect(elementTypes.length).toBeGreaterThanOrEqual(0);
-      console.log("Hot zone element types:", elementTypes);
-    }, 15000);
+			// Verify hot zones found actual interactive elements from aktunes.com
+			const elementTypes = hotZones.map(zone => zone.tagName).filter(Boolean);
+			expect(elementTypes.length).toBeGreaterThanOrEqual(0);
+			console.log('Hot zone element types:', elementTypes);
+		}, 15000);
 
-    test("intelligentScroll works with hot zones", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
-      const hotZones = await identifyHotZones(testPage);
+		test('intelligentScroll works with hot zones', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
+			const hotZones = await identifyHotZones(testPage);
 
-      await intelligentScroll(testPage, hotZones, consoleSpy);
+			await intelligentScroll(testPage, hotZones, consoleSpy);
 
-      // Scroll function may not always generate logs depending on page state
-      expect(logMessages.length).toBeGreaterThanOrEqual(0);
-    }, 10000);
+			// Scroll function may not always generate logs depending on page state
+			expect(logMessages.length).toBeGreaterThanOrEqual(0);
+		}, 10000);
 
-    test.skip("hoverOverElements uses persona and history", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
-      const hotZones = await identifyHotZones(testPage);
-      const hoverHistory = [];
+		test.skip('hoverOverElements uses persona and history', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
+			const hotZones = await identifyHotZones(testPage);
+			const hoverHistory = [];
 
-      await hoverOverElements(
-        testPage,
-        hotZones,
-        "powerUser",
-        hoverHistory,
-        consoleSpy,
-      );
+			await hoverOverElements(testPage, hotZones, 'powerUser', hoverHistory, consoleSpy);
 
-      // Hover function may not always generate logs depending on available elements
-      expect(logMessages.length).toBeGreaterThanOrEqual(0);
-    }, 15000);
+			// Hover function may not always generate logs depending on available elements
+			expect(logMessages.length).toBeGreaterThanOrEqual(0);
+		}, 15000);
 
-    test("naturalMouseMovement targets hot zones", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
-      const hotZones = await identifyHotZones(testPage);
+		test('naturalMouseMovement targets hot zones', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
+			const hotZones = await identifyHotZones(testPage);
 
-      await naturalMouseMovement(testPage, hotZones, consoleSpy);
+			await naturalMouseMovement(testPage, hotZones, consoleSpy);
 
-      expect(logMessages.length).toBeGreaterThan(0);
-    }, 10000);
-  });
+			expect(logMessages.length).toBeGreaterThan(0);
+		}, 10000);
+	});
 
-  describe("Sequence Execution", () => {
-    beforeEach(async () => {
-      // Create a simple test page with known elements
-      await testPage.setContent(`
+	describe('Sequence Execution', () => {
+		beforeEach(async () => {
+			// Create a simple test page with known elements
+			await testPage.setContent(`
         <html>
           <head><title>Test Page</title></head>
           <body>
@@ -665,303 +589,236 @@ describe("Meeple Modules - Unit Tests", () => {
           </body>
         </html>
       `);
-    });
+		});
 
-    test("validateSequence accepts valid sequence specification", () => {
-      const validSequence = {
-        description: "Test sequence",
-        temperature: 7,
-        "chaos-range": [1, 5],
-        actions: [
-          { action: "click", selector: "#testButton" },
-          { action: "type", selector: "#testInput", text: "test text" },
-          { action: "select", selector: "#testSelect", value: "option2" },
-        ],
-      };
+		test('validateSequence accepts valid sequence specification', () => {
+			const validSequence = {
+				description: 'Test sequence',
+				temperature: 7,
+				'chaos-range': [1, 5],
+				actions: [
+					{ action: 'click', selector: '#testButton' },
+					{ action: 'type', selector: '#testInput', text: 'test text' },
+					{ action: 'select', selector: '#testSelect', value: 'option2' }
+				]
+			};
 
-      const result = validateSequence(validSequence);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
+			const result = validateSequence(validSequence);
+			expect(result.valid).toBe(true);
+			expect(result.errors).toHaveLength(0);
+		});
 
-    test("validateSequence rejects invalid sequence specifications", () => {
-      const invalidSequence = {
-        description: "Invalid sequence",
-        temperature: 15, // Too high
-        "chaos-range": [5, 1], // Reversed range
-        actions: [
-          { action: "invalid", selector: "#test" }, // Invalid action type
-          { action: "type", selector: "#test" }, // Missing text field
-          { action: "select", selector: "#test" }, // Missing value field
-        ],
-      };
+		test('validateSequence rejects invalid sequence specifications', () => {
+			const invalidSequence = {
+				description: 'Invalid sequence',
+				temperature: 15, // Too high
+				'chaos-range': [5, 1], // Reversed range
+				actions: [
+					{ action: 'invalid', selector: '#test' }, // Invalid action type
+					{ action: 'type', selector: '#test' }, // Missing text field
+					{ action: 'select', selector: '#test' } // Missing value field
+				]
+			};
 
-      const result = validateSequence(invalidSequence);
-      expect(result.valid).toBe(false);
-      expect(result.errors.length).toBeGreaterThan(0);
-    });
+			const result = validateSequence(invalidSequence);
+			expect(result.valid).toBe(false);
+			expect(result.errors.length).toBeGreaterThan(0);
+		});
 
-    test("validateSequences handles multiple sequences", () => {
-      const sequences = {
-        "test-sequence-1": {
-          description: "First test",
-          actions: [{ action: "click", selector: "#test1" }],
-        },
-        "test-sequence-2": {
-          description: "Second test",
-          actions: [{ action: "type", selector: "#test2", text: "hello" }],
-        },
-      };
+		test('validateSequences handles multiple sequences', () => {
+			const sequences = {
+				'test-sequence-1': {
+					description: 'First test',
+					actions: [{ action: 'click', selector: '#test1' }]
+				},
+				'test-sequence-2': {
+					description: 'Second test',
+					actions: [{ action: 'type', selector: '#test2', text: 'hello' }]
+				}
+			};
 
-      const result = validateSequences(sequences);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
+			const result = validateSequences(sequences);
+			expect(result.valid).toBe(true);
+			expect(result.errors).toHaveLength(0);
+		});
 
-    test("executeSequence performs click actions", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('executeSequence performs click actions', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Click test",
-        temperature: 10, // High temperature for strict sequence following
-        "chaos-range": [10, 10], // No chaos
-        actions: [{ action: "click", selector: "#testButton" }],
-      };
+			const sequenceSpec = {
+				description: 'Click test',
+				temperature: 10, // High temperature for strict sequence following
+				'chaos-range': [10, 10], // No chaos
+				actions: [{ action: 'click', selector: '#testButton' }]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(1);
-      expect(results[0].action).toBe("click");
-      expect(results[0].selector).toBe("#testButton");
-      expect(logMessages.length).toBeGreaterThan(0);
-    }, 15000);
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(1);
+			expect(results[0].action).toBe('click');
+			expect(results[0].selector).toBe('#testButton');
+			expect(logMessages.length).toBeGreaterThan(0);
+		}, 15000);
 
-    test("executeSequence performs type actions", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('executeSequence performs type actions', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Type test",
-        temperature: 10,
-        "chaos-range": [10, 10],
-        actions: [
-          { action: "type", selector: "#testInput", text: "Hello World" },
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Type test',
+				temperature: 10,
+				'chaos-range': [10, 10],
+				actions: [{ action: 'type', selector: '#testInput', text: 'Hello World' }]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(1);
-      expect(results[0].action).toBe("type");
-      expect(results[0].text).toBe("Hello World");
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(1);
+			expect(results[0].action).toBe('type');
+			expect(results[0].text).toBe('Hello World');
 
-      // Verify text was actually typed
-      const inputValue = await testPage.$eval("#testInput", (el) => el.value);
-      expect(inputValue).toBe("Hello World");
-    }, 15000);
+			// Verify text was actually typed
+			const inputValue = await testPage.$eval('#testInput', el => el.value);
+			expect(inputValue).toBe('Hello World');
+		}, 15000);
 
-    test("executeSequence performs select actions", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('executeSequence performs select actions', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Select test",
-        temperature: 10,
-        "chaos-range": [10, 10],
-        actions: [
-          { action: "select", selector: "#testSelect", value: "option2" },
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Select test',
+				temperature: 10,
+				'chaos-range': [10, 10],
+				actions: [{ action: 'select', selector: '#testSelect', value: 'option2' }]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(1);
-      expect(results[0].action).toBe("select");
-      expect(results[0].value).toBe("option2");
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(1);
+			expect(results[0].action).toBe('select');
+			expect(results[0].value).toBe('option2');
 
-      // Verify option was actually selected
-      const selectedValue = await testPage.$eval(
-        "#testSelect",
-        (el) => el.value,
-      );
-      expect(selectedValue).toBe("option2");
-    }, 15000);
+			// Verify option was actually selected
+			const selectedValue = await testPage.$eval('#testSelect', el => el.value);
+			expect(selectedValue).toBe('option2');
+		}, 15000);
 
-    test.skip("executeSequence handles failed actions gracefully", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test.skip('executeSequence handles failed actions gracefully', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Failure test",
-        temperature: 10,
-        "chaos-range": [10, 10],
-        actions: [
-          { action: "click", selector: "#nonexistent" }, // This should fail
-          { action: "click", selector: "#testButton" }, // This should succeed
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Failure test',
+				temperature: 10,
+				'chaos-range': [10, 10],
+				actions: [
+					{ action: 'click', selector: '#nonexistent' }, // This should fail
+					{ action: 'click', selector: '#testButton' } // This should succeed
+				]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(2);
-      expect(results[0].success).toBe(false); // First action should fail
-      expect(results[1].success).toBe(true); // Second action should succeed
-    }, 15000);
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(2);
+			expect(results[0].success).toBe(false); // First action should fail
+			expect(results[1].success).toBe(true); // Second action should succeed
+		}, 15000);
 
-    test.skip("executeSequence respects temperature settings", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test.skip('executeSequence respects temperature settings', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Temperature test",
-        temperature: 0, // Very low temperature should cause random actions
-        "chaos-range": [10, 10],
-        actions: [
-          { action: "click", selector: "#testButton" },
-          { action: "click", selector: "#testButton" },
-          { action: "click", selector: "#testButton" },
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Temperature test',
+				temperature: 0, // Very low temperature should cause random actions
+				'chaos-range': [10, 10],
+				actions: [
+					{ action: 'click', selector: '#testButton' },
+					{ action: 'click', selector: '#testButton' },
+					{ action: 'click', selector: '#testButton' }
+				]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      // With temperature 0, should get some mix of defined and random actions
-      expect(results.length).toBeGreaterThan(0);
-      expect(logMessages.some((msg) => msg.includes("random action"))).toBe(
-        true,
-      );
-    }, 15000);
+			// Handle new return format
+			const results = result.actionResults || result;
+			// With temperature 0, should get some mix of defined and random actions
+			expect(results.length).toBeGreaterThan(0);
+			expect(logMessages.some(msg => msg.includes('random action'))).toBe(true);
+		}, 15000);
 
-    test("executeSequence includes chaos multiplier in temperature calculation", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('executeSequence includes chaos multiplier in temperature calculation', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Chaos test",
-        temperature: 5,
-        "chaos-range": [1, 10], // Wide chaos range
-        actions: [{ action: "click", selector: "#testButton" }],
-      };
+			const sequenceSpec = {
+				description: 'Chaos test',
+				temperature: 5,
+				'chaos-range': [1, 10], // Wide chaos range
+				actions: [{ action: 'click', selector: '#testButton' }]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results.length).toBeGreaterThan(0);
-      // Should log the effective temperature calculation
-      expect(
-        logMessages.some((msg) => msg.includes("Effective temperature")),
-      ).toBe(true);
-    }, 15000);
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results.length).toBeGreaterThan(0);
+			// Should log the effective temperature calculation
+			expect(logMessages.some(msg => msg.includes('Effective temperature'))).toBe(true);
+		}, 15000);
 
-    test("executeSequence handles multiple action types in sequence", async () => {
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+		test('executeSequence handles multiple action types in sequence', async () => {
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Multi-action test",
-        temperature: 10,
-        "chaos-range": [10, 10],
-        actions: [
-          { action: "type", selector: "#testInput", text: "Test123" },
-          { action: "select", selector: "#testSelect", value: "option1" },
-          { action: "click", selector: "#testButton" },
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Multi-action test',
+				temperature: 10,
+				'chaos-range': [10, 10],
+				actions: [
+					{ action: 'type', selector: '#testInput', text: 'Test123' },
+					{ action: 'select', selector: '#testSelect', value: 'option1' },
+					{ action: 'click', selector: '#testButton' }
+				]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(3);
-      expect(results[0].action).toBe("type");
-      expect(results[1].action).toBe("select");
-      expect(results[2].action).toBe("click");
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(3);
+			expect(results[0].action).toBe('type');
+			expect(results[1].action).toBe('select');
+			expect(results[2].action).toBe('click');
 
-      // Verify all actions were performed
-      const inputValue = await testPage.$eval("#testInput", (el) => el.value);
-      const selectValue = await testPage.$eval("#testSelect", (el) => el.value);
-      expect(inputValue).toBe("Test123");
-      expect(selectValue).toBe("option1");
-    }, 20000);
+			// Verify all actions were performed
+			const inputValue = await testPage.$eval('#testInput', el => el.value);
+			const selectValue = await testPage.$eval('#testSelect', el => el.value);
+			expect(inputValue).toBe('Test123');
+			expect(selectValue).toBe('option1');
+		}, 20000);
 
-    test("executeSequence handles fillOutForm action for radio groups", async () => {
-      // Create page with radio groups
-      await testPage.setContent(`
+		test('executeSequence handles fillOutForm action for radio groups', async () => {
+			// Create page with radio groups
+			await testPage.setContent(`
         <html>
           <body>
             <div role="radiogroup" id="group1">
@@ -976,73 +833,65 @@ describe("Meeple Modules - Unit Tests", () => {
         </html>
       `);
 
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Fill out form test",
-        temperature: 10,
-        "chaos-range": [10, 10],
-        actions: [
-          {
-            action: "fillOutForm",
-            selector: "[role=radiogroup]",
-            clicksPerGroup: 2,
-          },
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Fill out form test',
+				temperature: 10,
+				'chaos-range': [10, 10],
+				actions: [
+					{
+						action: 'fillOutForm',
+						selector: '[role=radiogroup]',
+						clicksPerGroup: 2
+					}
+				]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(1);
-      expect(results[0].action).toBe("fillOutForm");
-      expect(results[0].success).toBe(true);
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(1);
+			expect(results[0].action).toBe('fillOutForm');
+			expect(results[0].success).toBe(true);
 
-      // Verify at least one radio was selected in each group
-      const group1Checked = await testPage.evaluate(() => {
-        const radios = document.querySelectorAll('#group1 input[type="radio"]');
-        return Array.from(radios).some((r) => r.checked);
-      });
-      const group2Checked = await testPage.evaluate(() => {
-        const radios = document.querySelectorAll('#group2 input[type="radio"]');
-        return Array.from(radios).some((r) => r.checked);
-      });
+			// Verify at least one radio was selected in each group
+			const group1Checked = await testPage.evaluate(() => {
+				const radios = document.querySelectorAll('#group1 input[type="radio"]');
+				return Array.from(radios).some(r => r.checked);
+			});
+			const group2Checked = await testPage.evaluate(() => {
+				const radios = document.querySelectorAll('#group2 input[type="radio"]');
+				return Array.from(radios).some(r => r.checked);
+			});
 
-      expect(group1Checked).toBe(true);
-      expect(group2Checked).toBe(true);
-    }, 15000);
+			expect(group1Checked).toBe(true);
+			expect(group2Checked).toBe(true);
+		}, 15000);
 
-    test("validateSequence accepts fillOutForm action type", () => {
-      const validSequence = {
-        description: "Form filling sequence",
-        temperature: 8,
-        actions: [
-          {
-            action: "fillOutForm",
-            selector: "[role=radiogroup]",
-            clicksPerGroup: 5,
-          },
-        ],
-      };
+		test('validateSequence accepts fillOutForm action type', () => {
+			const validSequence = {
+				description: 'Form filling sequence',
+				temperature: 8,
+				actions: [
+					{
+						action: 'fillOutForm',
+						selector: '[role=radiogroup]',
+						clicksPerGroup: 5
+					}
+				]
+			};
 
-      const result = validateSequence(validSequence);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
+			const result = validateSequence(validSequence);
+			expect(result.valid).toBe(true);
+			expect(result.errors).toHaveLength(0);
+		});
 
-    test("executeSequence handles requireActive flag", async () => {
-      await testPage.setContent(`
+		test('executeSequence handles requireActive flag', async () => {
+			await testPage.setContent(`
         <html>
           <body>
             <button id="activeButton">Active</button>
@@ -1051,44 +900,36 @@ describe("Meeple Modules - Unit Tests", () => {
         </html>
       `);
 
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
 
-      const sequenceSpec = {
-        description: "Conditional click test",
-        temperature: 10,
-        "chaos-range": [10, 10],
-        actions: [
-          { action: "click", selector: "#disabledButton", requireActive: true },
-          { action: "click", selector: "#activeButton", requireActive: true },
-        ],
-      };
+			const sequenceSpec = {
+				description: 'Conditional click test',
+				temperature: 10,
+				'chaos-range': [10, 10],
+				actions: [
+					{ action: 'click', selector: '#disabledButton', requireActive: true },
+					{ action: 'click', selector: '#activeButton', requireActive: true }
+				]
+			};
 
-      const hotZones = [];
-      const result = await executeSequence(
-        testPage,
-        sequenceSpec,
-        hotZones,
-        "researcher",
-        "test-user",
-        {},
-        consoleSpy,
-      );
+			const hotZones = [];
+			const result = await executeSequence(testPage, sequenceSpec, hotZones, 'researcher', 'test-user', {}, consoleSpy);
 
-      // Handle new return format
-      const results = result.actionResults || result;
-      expect(results).toHaveLength(2);
-      // First result should be skipped (disabled button)
-      expect(results[0]).toHaveProperty("skipped");
-      expect(results[0].skipped).toBe(true);
-      // Second result should succeed (active button)
-      expect(results[1].success).toBe(true);
-    }, 15000);
-  });
+			// Handle new return format
+			const results = result.actionResults || result;
+			expect(results).toHaveLength(2);
+			// First result should be skipped (disabled button)
+			expect(results[0]).toHaveProperty('skipped');
+			expect(results[0].skipped).toBe(true);
+			// Second result should succeed (active button)
+			expect(results[1].success).toBe(true);
+		}, 15000);
+	});
 
-  describe("Hot Zones - Form Detection", () => {
-    test("identifyHotZones detects form elements as hot zones", async () => {
-      await testPage.setContent(`
+	describe('Hot Zones - Form Detection', () => {
+		test('identifyHotZones detects form elements as hot zones', async () => {
+			await testPage.setContent(`
         <html>
           <head>
             <style>
@@ -1121,41 +962,39 @@ describe("Meeple Modules - Unit Tests", () => {
         </html>
       `);
 
-      const logMessages = [];
-      const consoleSpy = (message) => logMessages.push(message);
-      const hotZones = await identifyHotZones(testPage);
+			const logMessages = [];
+			const consoleSpy = message => logMessages.push(message);
+			const hotZones = await identifyHotZones(testPage);
 
-      expect(Array.isArray(hotZones)).toBe(true);
+			expect(Array.isArray(hotZones)).toBe(true);
 
-      // Should find form elements (with styling, they should be prominent enough)
-      const formHotZones = hotZones.filter((zone) => zone.isForm);
+			// Should find form elements (with styling, they should be prominent enough)
+			const formHotZones = hotZones.filter(zone => zone.isForm);
 
-      console.log("Total hot zones:", hotZones.length);
-      console.log(
-        "Form hot zones found:",
-        formHotZones.map((z) => ({
-          tag: z.tag,
-          type: z.formType,
-          role: z.ariaRole,
-          priority: z.priority,
-        })),
-      );
+			console.log('Total hot zones:', hotZones.length);
+			console.log(
+				'Form hot zones found:',
+				formHotZones.map(z => ({
+					tag: z.tag,
+					type: z.formType,
+					role: z.ariaRole,
+					priority: z.priority
+				}))
+			);
 
-      // With proper styling, should detect at least some form elements
-      // Note: Not all form elements may meet the visual prominence threshold
-      expect(formHotZones.length).toBeGreaterThanOrEqual(0);
+			// With proper styling, should detect at least some form elements
+			// Note: Not all form elements may meet the visual prominence threshold
+			expect(formHotZones.length).toBeGreaterThanOrEqual(0);
 
-      // If form hot zones are found, verify they have proper structure
-      if (formHotZones.length > 0) {
-        const formTypes = formHotZones
-          .map((zone) => zone.formType)
-          .filter(Boolean);
-        expect(formTypes.length).toBeGreaterThan(0);
-      }
-    }, 15000);
+			// If form hot zones are found, verify they have proper structure
+			if (formHotZones.length > 0) {
+				const formTypes = formHotZones.map(zone => zone.formType).filter(Boolean);
+				expect(formTypes.length).toBeGreaterThan(0);
+			}
+		}, 15000);
 
-    test("form hot zones include proper metadata when detected", async () => {
-      await testPage.setContent(`
+		test('form hot zones include proper metadata when detected', async () => {
+			await testPage.setContent(`
         <html>
           <head>
             <style>
@@ -1184,73 +1023,69 @@ describe("Meeple Modules - Unit Tests", () => {
         </html>
       `);
 
-      const hotZones = await identifyHotZones(testPage);
-      const formZones = hotZones.filter((zone) => zone.isForm);
+			const hotZones = await identifyHotZones(testPage);
+			const formZones = hotZones.filter(zone => zone.isForm);
 
-      console.log("Form zones with metadata:", formZones);
+			console.log('Form zones with metadata:', formZones);
 
-      // If form zones are detected, verify metadata structure
-      if (formZones.length > 0) {
-        const textInput = formZones.find(
-          (zone) => zone.tag === "input" && zone.formType === "text",
-        );
-        if (textInput) {
-          expect(textInput.isForm).toBe(true);
-          expect(textInput.formType).toBeTruthy();
-          expect(textInput.formName).toBe("user");
-          expect(textInput.formPlaceholder).toBe("Enter username");
-        }
+			// If form zones are detected, verify metadata structure
+			if (formZones.length > 0) {
+				const textInput = formZones.find(zone => zone.tag === 'input' && zone.formType === 'text');
+				if (textInput) {
+					expect(textInput.isForm).toBe(true);
+					expect(textInput.formType).toBeTruthy();
+					expect(textInput.formName).toBe('user');
+					expect(textInput.formPlaceholder).toBe('Enter username');
+				}
 
-        const radioGroup = formZones.find(
-          (zone) => zone.ariaRole === "radiogroup",
-        );
-        if (radioGroup) {
-          expect(radioGroup.isForm).toBe(true);
-        }
-      }
+				const radioGroup = formZones.find(zone => zone.ariaRole === 'radiogroup');
+				if (radioGroup) {
+					expect(radioGroup.isForm).toBe(true);
+				}
+			}
 
-      // Test passes regardless - metadata structure is validated when elements are found
-      expect(true).toBe(true);
-    }, 15000);
-  });
+			// Test passes regardless - metadata structure is validated when elements are found
+			expect(true).toBe(true);
+		}, 15000);
+	});
 
-  describe("Microsites Orchestrator", () => {
-    test("sequence JSON files are valid and loadable", async () => {
-      const fs = await import("fs/promises");
-      const path = await import("path");
+	describe('Microsites Orchestrator', () => {
+		test('sequence JSON files are valid and loadable', async () => {
+			const fs = await import('fs/promises');
+			const path = await import('path');
 
-      // Check that sequence files exist and are valid JSON
-      const sequencesDir = path.join(process.cwd(), "sequences");
+			// Check that sequence files exist and are valid JSON
+			const sequencesDir = path.join(process.cwd(), 'sequences');
 
-      try {
-        const files = await fs.readdir(sequencesDir);
-        const jsonFiles = files.filter((f) => f.endsWith(".json"));
+			try {
+				const files = await fs.readdir(sequencesDir);
+				const jsonFiles = files.filter(f => f.endsWith('.json'));
 
-        expect(jsonFiles.length).toBeGreaterThan(0);
+				expect(jsonFiles.length).toBeGreaterThan(0);
 
-        // Load and validate each sequence file
-        for (const file of jsonFiles) {
-          const filePath = path.join(sequencesDir, file);
-          const content = await fs.readFile(filePath, "utf-8");
-          const sequence = JSON.parse(content);
+				// Load and validate each sequence file
+				for (const file of jsonFiles) {
+					const filePath = path.join(sequencesDir, file);
+					const content = await fs.readFile(filePath, 'utf-8');
+					const sequence = JSON.parse(content);
 
-          // Basic structure validation
-          expect(sequence).toHaveProperty("actions");
-          expect(Array.isArray(sequence.actions)).toBe(true);
-          expect(sequence.actions.length).toBeGreaterThan(0);
+					// Basic structure validation
+					expect(sequence).toHaveProperty('actions');
+					expect(Array.isArray(sequence.actions)).toBe(true);
+					expect(sequence.actions.length).toBeGreaterThan(0);
 
-          // Validate using our validation function
-          const validation = validateSequence(sequence);
-          if (!validation.valid) {
-            console.error(`Validation errors in ${file}:`, validation.errors);
-          }
-          expect(validation.valid).toBe(true);
-        }
+					// Validate using our validation function
+					const validation = validateSequence(sequence);
+					if (!validation.valid) {
+						console.error(`Validation errors in ${file}:`, validation.errors);
+					}
+					expect(validation.valid).toBe(true);
+				}
 
-        console.log(`Validated ${jsonFiles.length} sequence files`);
-      } catch (error) {
-        console.warn("Sequences directory not found or empty:", error.message);
-      }
-    }, 10000);
-  });
+				console.log(`Validated ${jsonFiles.length} sequence files`);
+			} catch (error) {
+				console.warn('Sequences directory not found or empty:', error.message);
+			}
+		}, 10000);
+	});
 });

--- a/ui/ui.html
+++ b/ui/ui.html
@@ -230,20 +230,38 @@
 
 					<label> <input type="checkbox" id="past" name="past" /> Simulate time in past </label>
 
-					<div id="friction-section" style="margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.1);">
-						<p style="margin: 4px 0; font-size: 0.85em; color: #888;"><b>Friction Behaviors</b></p>
-						<div style="display: flex; align-items: center; gap: 20px; flex-wrap: wrap;">
-							<label style="font-size: 0.9em;">
+					<div
+						id="friction-section"
+						style="margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255, 255, 255, 0.1)"
+					>
+						<p style="margin: 4px 0; font-size: 0.85em; color: #888"><b>Friction Behaviors</b></p>
+						<div style="display: flex; align-items: center; gap: 20px; flex-wrap: wrap">
+							<label style="font-size: 0.9em">
 								Network:
-								<select id="networkProfile" name="networkProfile" style="margin-left: 4px; padding: 2px 4px; background: #1a1a2e; color: #fff; border: 1px solid #333; border-radius: 4px;">
+								<select
+									id="networkProfile"
+									name="networkProfile"
+									style="
+										margin-left: 4px;
+										padding: 2px 4px;
+										background: #1a1a2e;
+										color: #fff;
+										border: 1px solid #333;
+										border-radius: 4px;
+									"
+								>
 									<option value="fast">Fast (default)</option>
 									<option value="moderate">Moderate (2 Mbps)</option>
 									<option value="slow4g">Slow 4G</option>
 									<option value="slow3g">Slow 3G</option>
 								</select>
 							</label>
-							<label style="font-size: 0.9em;"> <input type="checkbox" id="chaosMode" name="chaosMode" /> Chaos Mode </label>
-							<label style="font-size: 0.9em;"> <input type="checkbox" id="formMistakes" name="formMistakes" /> Form Mistakes </label>
+							<label style="font-size: 0.9em">
+								<input type="checkbox" id="chaosMode" name="chaosMode" /> Chaos Mode
+							</label>
+							<label style="font-size: 0.9em">
+								<input type="checkbox" id="formMistakes" name="formMistakes" /> Form Mistakes
+							</label>
 						</div>
 					</div>
 


### PR DESCRIPTION
## Summary
- Rewrote CLAUDE.md from scratch (452→112 lines) — cut API reference docs, added missing modules, added known issues section
- Added 3 Claude Code skills: `/ship` (dual-service deploy via CI), `/logs` (Cloud Run log queries for both services), `/verify` (pre-ship quality gate with known error baseline)
- Fixed pre-existing lint errors in `browser.js` (setter return value, empty catch block)
- Applied Prettier formatting across codebase (10+ files, whitespace-only)
- Updated `.gitignore` to track `CLAUDE.md` and `.claude/skills/` while keeping `settings.local.json` local

## Services affected
- **UI** (`npc-mixpanel`) — Cloud Run, private/IAP
- **API** (`npc-mixpanel-api`) — Cloud Run, public

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format:check` passes
- [x] `npm test` passes (49 passed, 3 skipped)
- [ ] Typecheck has 6 known pre-existing errors (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)